### PR TITLE
Change User.active() to synchronous val User.active

### DIFF
--- a/pubnub-chat-api/api/pubnub-chat-api.api
+++ b/pubnub-chat-api/api/pubnub-chat-api.api
@@ -316,6 +316,7 @@ public abstract interface class com/pubnub/chat/User {
 	public abstract fun active ()Lcom/pubnub/kmp/PNFuture;
 	public abstract fun delete (Z)Lcom/pubnub/kmp/PNFuture;
 	public static synthetic fun delete$default (Lcom/pubnub/chat/User;ZILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;
+	public abstract fun getActive ()Z
 	public abstract fun getChannelRestrictions (Lcom/pubnub/chat/Channel;)Lcom/pubnub/kmp/PNFuture;
 	public abstract fun getChannelsRestrictions (Ljava/lang/Integer;Lcom/pubnub/api/models/consumer/objects/PNPage;Ljava/util/Collection;)Lcom/pubnub/kmp/PNFuture;
 	public static synthetic fun getChannelsRestrictions$default (Lcom/pubnub/chat/User;Ljava/lang/Integer;Lcom/pubnub/api/models/consumer/objects/PNPage;Ljava/util/Collection;ILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/User.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/User.kt
@@ -70,6 +70,11 @@ interface User {
     val lastActiveTimestamp: Long?
 
     /**
+     * Indicates whether the user is currently (at the time of obtaining this `User` object) active.
+     */
+    val active: Boolean
+
+    /**
      * Updates the metadata of the user with the provided details.
      *
      * @param name The new name for the user.
@@ -187,6 +192,7 @@ interface User {
      *
      * @return [PNFuture] containing a boolean indicating whether the user is active.
      */
+    @Deprecated("Use non-async `active` property instead.", ReplaceWith("active"))
     fun active(): PNFuture<Boolean>
 
     /**

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/UserIntegrationTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/UserIntegrationTest.kt
@@ -162,7 +162,7 @@ class UserIntegrationTest : BaseChatIntegrationTest() {
     @Test
     fun calling_active_should_throw_exception_when_storeUserActivityTimestamps_is_false() = runTest {
         val e = assertFailsWith<PubNubException> {
-            someUser.active().await()
+            someUser.active
         }
 
         assertEquals(
@@ -181,7 +181,7 @@ class UserIntegrationTest : BaseChatIntegrationTest() {
         someUser = chatNew.currentUser
 
         // when
-        val isUserActive = someUser.active().await()
+        val isUserActive = someUser.active
 
         // then
         assertTrue(isUserActive)
@@ -201,7 +201,7 @@ class UserIntegrationTest : BaseChatIntegrationTest() {
         someUser = chatNew2.currentUser
 
         // when
-        val isUserActive = someUser.active().await()
+        val isUserActive = someUser.active
 
         // then
         assertTrue(isUserActive)


### PR DESCRIPTION
Deprecate `fun User.active()` that returns asynchronous PNFuture and replace it with `val User.active: Boolean` to match TS Chat SDK.
It was a mistake when translating from TS to make this asynchronous, and it doesn't need to be async.