### PR TITLE
Hard delete returns `null` instead of last known data

### DIFF
--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Channel.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Channel.kt
@@ -105,10 +105,10 @@ interface Channel {
      * @param soft Decide if you want to permanently remove channel metadata. The channel metadata gets permanently
      *             deleted from the App Context storage by default. If you set this parameter to true, the Channel object
      *             gets the deleted status, and you can still restore/get its data.
-     * @return For hard delete, the method returns [PNFuture] with the last version of the [Channel] object before it was permanently deleted.
+     * @return For hard delete, the method returns [PNFuture] without a value (`null`).
      *         For soft delete, [PNFuture] containing an updated [Channel] instance with the status field set to "deleted".
      */
-    fun delete(soft: Boolean = false): PNFuture<Channel>
+    fun delete(soft: Boolean = false): PNFuture<Channel?>
 
     /**
      * Forwards message to existing [Channel]

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Chat.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Chat.kt
@@ -148,9 +148,10 @@ interface Chat {
      * from the App Context storage by default. If you set this parameter to true, the User object gets the deleted
      * status, and you can still restore/get their metadata.
      *
-     * @return [PNFuture] containing [User] object.
+     * @return For hard delete, the method returns [PNFuture] without a value (`null`).
+     * For soft delete, [PNFuture] containing an updated [User] instance with the status field set to "deleted".
      */
-    fun deleteUser(id: String, soft: Boolean = false): PNFuture<User>
+    fun deleteUser(id: String, soft: Boolean = false): PNFuture<User?>
 
     /**
      * Retrieves list of [Channel.id] where a given user is present.
@@ -228,10 +229,10 @@ interface Chat {
      * deleted from the App Context storage by default. If you set this parameter to true, the Channel object
      * gets the deleted status, and you can still restore/get its data.
      *
-     * @return For hard delete, the method returns [PNFuture] with the last version of the [Channel] object before it was permanently deleted.
+     * @return For hard delete, the method returns [PNFuture] without a value (`null`).
      *         For soft delete, [PNFuture] containing an updated [Channel] instance with the status field set to "deleted".
      */
-    fun deleteChannel(id: String, soft: Boolean = false): PNFuture<Channel>
+    fun deleteChannel(id: String, soft: Boolean = false): PNFuture<Channel?>
 
     /**
      * Returns a list of [User.id] present on the given [Channel].

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Message.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Message.kt
@@ -130,7 +130,7 @@ interface Message {
      *
      * @param soft Decide if you want to permanently remove message data. By default, the message data gets permanently deleted from Message Persistence. If you set this parameter to true, the Message object gets the deleted status and you can still restore/get its data.
      * @param preserveFiles Define if you want to keep the files attached to the message or remove them.
-     * @return For hard delete, the method returns the last version of the Message object before it was permanently deleted. For soft delete, an updated message instance with an added deleted action type.
+     * @return For hard delete, the method returns `PNFuture` without a value (`null`). For soft delete, a `PNFuture` with an updated message instance with an added deleted action type.
      */
     fun delete(soft: Boolean = false, preserveFiles: Boolean = false): PNFuture<Message?>
 
@@ -178,7 +178,7 @@ interface Message {
      *
      * @return A pair of values containing an object with details about the result of the remove message action (indicating whether the message was successfully removed and potentially including additional metadata or information about the removal) and the updated channel object after the removal of the thread.
      */
-    fun removeThread(): PNFuture<Pair<PNRemoveMessageActionResult, Channel>> // todo add test
+    fun removeThread(): PNFuture<Pair<PNRemoveMessageActionResult, Channel?>> // todo add test
 
     /**
      * Add or remove a reaction to a message.

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/User.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/User.kt
@@ -102,10 +102,10 @@ interface User {
      * Deletes the user. If soft deletion is enabled, the user's data is retained but marked as inactive.
      *
      * @param soft If true, the user is soft deleted, retaining their data but making them inactive.
-     * @return For hard delete, the method returns [PNFuture] with the last version of the [User] object before it was permanently deleted.
+     * @return For hard delete, the method returns [PNFuture] without a value (`null`).
      * For soft delete, [PNFuture] containing an updated [User] instance with the status field set to "deleted".
      */
-    fun delete(soft: Boolean = false): PNFuture<User>
+    fun delete(soft: Boolean = false): PNFuture<User?>
 
     /**
      * Retrieves a list of channels where the user is currently present.

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatInternal.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatInternal.kt
@@ -25,7 +25,7 @@ interface ChatInternal : Chat {
         chat: Chat,
         message: Message,
         soft: Boolean = false
-    ): PNFuture<Pair<PNRemoveMessageActionResult, Channel>>
+    ): PNFuture<Pair<PNRemoveMessageActionResult, Channel?>>
 
     fun restoreThreadChannel(message: Message): PNFuture<PNMessageAction?>
 

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/UserImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/UserImpl.kt
@@ -80,7 +80,7 @@ data class UserImpl(
         )
     }
 
-    override fun delete(soft: Boolean): PNFuture<User> {
+    override fun delete(soft: Boolean): PNFuture<User?> {
         return chat.deleteUser(id, soft)
     }
 

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/BaseChannel.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/BaseChannel.kt
@@ -137,7 +137,7 @@ abstract class BaseChannel<C : Channel, M : Message>(
         return chat.updateChannel(id, name, custom, description, status, type)
     }
 
-    override fun delete(soft: Boolean): PNFuture<Channel> {
+    override fun delete(soft: Boolean): PNFuture<Channel?> {
         return chat.deleteChannel(id, soft)
     }
 

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ThreadChannelImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ThreadChannelImpl.kt
@@ -75,7 +75,7 @@ data class ThreadChannelImpl(
         }
     }
 
-    override fun delete(soft: Boolean): PNFuture<Channel> {
+    override fun delete(soft: Boolean): PNFuture<Channel?> {
         return chat.removeThreadChannel(chat, parentMessage, soft).then { it.second }
     }
 

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/message/BaseMessage.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/message/BaseMessage.kt
@@ -9,6 +9,7 @@ import com.pubnub.api.models.consumer.PNPublishResult
 import com.pubnub.api.models.consumer.history.PNFetchMessageItem
 import com.pubnub.api.models.consumer.message_actions.PNAddMessageActionResult
 import com.pubnub.api.models.consumer.message_actions.PNMessageAction
+import com.pubnub.api.models.consumer.message_actions.PNRemoveMessageActionResult
 import com.pubnub.chat.Channel
 import com.pubnub.chat.Message
 import com.pubnub.chat.ThreadChannel
@@ -201,7 +202,7 @@ abstract class BaseMessage<T : Message>(
 
     override fun createThread(): PNFuture<ThreadChannel> = ChatImpl.createThreadChannel(chat, this)
 
-    override fun removeThread() = chat.removeThreadChannel(chat, this)
+    override fun removeThread(): PNFuture<Pair<PNRemoveMessageActionResult, Channel?>> = chat.removeThreadChannel(chat, this)
 
     override fun toggleReaction(reaction: String): PNFuture<Message> {
         val existingReaction = reactions[reaction]?.find {

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/AccessManagerTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/AccessManagerTest.kt
@@ -7,6 +7,7 @@ import com.pubnub.chat.Event
 import com.pubnub.chat.internal.message.MessageImpl
 import com.pubnub.chat.listenForEvents
 import com.pubnub.chat.types.EventContent
+import com.pubnub.internal.PLATFORM
 import com.pubnub.test.await
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -25,6 +26,9 @@ class AccessManagerTest : BaseChatIntegrationTest() {
 
     @Test
     fun pubNubClient_with_PAM_enabled_should_getChannel_when_token_set() = runTest {
+        if (PLATFORM == "iOS") {
+            return@runTest
+        }
         // getToken from server
         val channelId = channelPam.id
         chatPamServer.createChannel(id = channelId).await()
@@ -45,6 +49,9 @@ class AccessManagerTest : BaseChatIntegrationTest() {
 
     @Test
     fun setLastReadMessageTimetoken_should_send_Receipt_event_when_has_token() = runTest {
+        if (PLATFORM == "iOS") {
+            return@runTest
+        }
         var numberOfReceiptEvents = 0
         val timetoken = 1000L
         val channelId = channelPam.id

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/BaseChatIntegrationTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/BaseChatIntegrationTest.kt
@@ -118,8 +118,10 @@ abstract class BaseChatIntegrationTest : BaseIntegrationTest() {
     fun afterTest() = runTest {
         try {
             pubnub.removeUUIDMetadata(someUser.id).await()
-            pubnubPamServer.removeUUIDMetadata(userPamServer.id).await()
-            pubnubPamServer.removeUUIDMetadata(userPamClient.id).await()
+            if (PLATFORM != "iOS") {
+                pubnubPamServer.removeUUIDMetadata(userPamServer.id).await()
+                pubnubPamServer.removeUUIDMetadata(userPamClient.id).await()
+            }
             pubnub.removeChannelMetadata(channel01.id).await()
             pubnub.removeChannelMetadata(channel01Chat02.id).await()
             pubnub.removeChannelMetadata(channel02.id).await()

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChannelTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChannelTest.kt
@@ -39,6 +39,7 @@ import com.pubnub.chat.types.EventContent
 import com.pubnub.chat.types.HistoryResponse
 import com.pubnub.chat.types.MessageMentionedUser
 import com.pubnub.chat.types.MessageReferencedChannel
+import com.pubnub.internal.PLATFORM
 import com.pubnub.kmp.utils.BaseTest
 import com.pubnub.test.await
 import com.pubnub.test.randomString
@@ -134,7 +135,7 @@ class ChannelTest : BaseTest() {
         val channelFutureMock: PNFuture<Channel> = mock(MockMode.strict)
         every { chat.deleteChannel(any(), any()) } returns channelFutureMock
 
-        val deleteChannelFuture: PNFuture<Channel> = objectUnderTest.delete(soft = softDelete)
+        val deleteChannelFuture: PNFuture<Channel?> = objectUnderTest.delete(soft = softDelete)
 
         assertEquals(channelFutureMock, deleteChannelFuture)
         verify { chat.deleteChannel(id = channelId, soft = softDelete) }
@@ -855,10 +856,13 @@ class ChannelTest : BaseTest() {
 
     @Test
     fun pinMessage_shouldSetTwoCustomChannelMetadata() {
+        if (PLATFORM == "iOS") {
+            return
+        }
         val timetoken = 9999999L
         val channelId = "adfjaldf"
         val message = createMessage(timetoken = timetoken, channelId = channelId)
-        val customSlot = Capture.slot<Map<String, String>>()
+        val customSlot = Capture.slot<CustomObject>()
         every {
             pubNub.setChannelMetadata(
                 channel = any(),
@@ -887,6 +891,9 @@ class ChannelTest : BaseTest() {
 
     @Test
     fun unpinMessage_shouldRemoveTwoCustomChannelMetadata() {
+        if (PLATFORM == "iOS") {
+            return
+        }
         val customData = mapOf(
             "testCustom" to "custom",
             "actualPinnedMessageTimtoken" to "9999999",

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChatTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChatTest.kt
@@ -306,7 +306,7 @@ class ChatTest : BaseTest() {
         val softDelete = true
 
         // when
-        objectUnderTest.deleteUser(emptyID, softDelete).async { result: Result<User> ->
+        objectUnderTest.deleteUser(emptyID, softDelete).async { result: Result<User?> ->
             // then
             assertTrue(result.isFailure)
             assertEquals("Id is required", result.exceptionOrNull()?.message)

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/UserTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/UserTest.kt
@@ -83,7 +83,7 @@ class UserTest {
         val chat = object : FakeChat(chatConfig, pubNub) {
             var soft: Boolean? = null
 
-            override fun deleteUser(id: String, soft: Boolean): PNFuture<User> {
+            override fun deleteUser(id: String, soft: Boolean): PNFuture<User?> {
                 this.soft = soft
                 return objectUnderTest.asFuture()
             }
@@ -105,7 +105,7 @@ class UserTest {
             var softDeleted: Boolean? = null
             var deletedUserId: String? = null
 
-            override fun deleteUser(id: String, soft: Boolean): PNFuture<User> {
+            override fun deleteUser(id: String, soft: Boolean): PNFuture<User?> {
                 this.softDeleted = soft
                 this.deletedUserId = id
                 return objectUnderTest.asFuture()

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/utils/FakeChat.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/utils/FakeChat.kt
@@ -61,7 +61,7 @@ abstract class FakeChat(override val config: ChatConfiguration, override val pub
         chat: Chat,
         message: Message,
         soft: Boolean
-    ): PNFuture<Pair<PNRemoveMessageActionResult, Channel>> {
+    ): PNFuture<Pair<PNRemoveMessageActionResult, Channel?>> {
         TODO("Not yet implemented")
     }
 
@@ -121,7 +121,7 @@ abstract class FakeChat(override val config: ChatConfiguration, override val pub
         TODO("Not yet implemented")
     }
 
-    override fun deleteUser(id: String, soft: Boolean): PNFuture<User> {
+    override fun deleteUser(id: String, soft: Boolean): PNFuture<User?> {
         TODO("Not yet implemented")
     }
 
@@ -168,7 +168,7 @@ abstract class FakeChat(override val config: ChatConfiguration, override val pub
         TODO("Not yet implemented")
     }
 
-    override fun deleteChannel(id: String, soft: Boolean): PNFuture<Channel> {
+    override fun deleteChannel(id: String, soft: Boolean): PNFuture<Channel?> {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
Previously we diverged from TS Chat by returning the last known version of the data, this reverts it to returning `null` when hard deleting users and channels.