### PR TITLE
Fix toggleReaction

### DIFF
--- a/pubnub-chat-api/api/pubnub-chat-api.api
+++ b/pubnub-chat-api/api/pubnub-chat-api.api
@@ -366,12 +366,13 @@ public final class com/pubnub/chat/config/ChatConfigurationKt {
 
 public final class com/pubnub/chat/config/CustomPayloads {
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDeleteMessageActionName ()Ljava/lang/String;
 	public final fun getEditMessageActionName ()Ljava/lang/String;
 	public final fun getGetMessagePublishBody ()Lkotlin/jvm/functions/Function3;
 	public final fun getGetMessageResponseBody ()Lkotlin/jvm/functions/Function3;
+	public final fun getReactionsActionName ()Ljava/lang/String;
 }
 
 public final class com/pubnub/chat/config/LogLevel : java/lang/Enum {

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/config/CustomPayloads.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/config/CustomPayloads.kt
@@ -52,4 +52,5 @@ class CustomPayloads(
      *
      */
     val deleteMessageActionName: String? = null,
+    val reactionsActionName: String? = null
 )

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatImpl.kt
@@ -124,6 +124,8 @@ class ChatImpl(
         ?: MessageActionType.EDITED.toString(),
     override val deleteMessageActionName: String = config.customPayloads?.deleteMessageActionName
         ?: MessageActionType.DELETED.toString(),
+    override val reactionsActionName: String = config.customPayloads?.reactionsActionName
+        ?: MessageActionType.REACTIONS.toString(),
     override val timerManager: TimerManager = createTimerManager()
 ) : ChatInternal {
     override var currentUser: User =

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatInternal.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatInternal.kt
@@ -16,6 +16,7 @@ import com.pubnub.kmp.PNFuture
 interface ChatInternal : Chat {
     val editMessageActionName: String
     val deleteMessageActionName: String
+    val reactionsActionName: String
     val timerManager: TimerManager
 
     fun createUser(user: User): PNFuture<User>

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/message/BaseMessage.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/message/BaseMessage.kt
@@ -30,7 +30,6 @@ import com.pubnub.chat.internal.util.logWarnAndReturnException
 import com.pubnub.chat.internal.util.pnError
 import com.pubnub.chat.types.EventContent
 import com.pubnub.chat.types.File
-import com.pubnub.chat.types.MessageActionType
 import com.pubnub.chat.types.MessageMentionedUser
 import com.pubnub.chat.types.MessageMentionedUsers
 import com.pubnub.chat.types.MessageReferencedChannel
@@ -93,7 +92,7 @@ abstract class BaseMessage<T : Message>(
         get() = content.files ?: emptyList()
 
     override val reactions: Map<String, List<PNFetchMessageItem.Action>>
-        get() = actions?.get(MessageActionType.REACTIONS.toString()) ?: emptyMap()
+        get() = actions?.get(chat.reactionsActionName) ?: emptyMap()
 
     override val textLinks: List<TextLink>? get() = (
         meta?.get(
@@ -209,7 +208,10 @@ abstract class BaseMessage<T : Message>(
             it.uuid == chat.currentUser.id
         }
         val messageAction =
-            PNMessageAction(MessageActionType.REACTIONS.toString(), reaction, timetoken)
+            PNMessageAction(chat.reactionsActionName, reaction, timetoken).apply {
+                actionTimetoken = existingReaction?.actionTimetoken
+                uuid = chat.currentUser.id
+            }
         val newActions = if (existingReaction != null) {
             chat.pubNub.removeMessageAction(channelId, timetoken, existingReaction.actionTimetoken.toLong())
                 .then { filterAction(actions, messageAction) }

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/utils/FakeChat.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/utils/FakeChat.kt
@@ -42,6 +42,9 @@ abstract class FakeChat(override val config: ChatConfiguration, override val pub
         TODO("Not yet implemented")
     }
 
+    override val reactionsActionName: String
+        get() = TODO("Not yet implemented")
+
     override val currentUser: User
         get() = TODO("Not yet implemented")
 


### PR DESCRIPTION
There was a bug where removing a reaction would not remove it from the returned value.

Additionally we were missing a configurable `reactionsActionName` from TS Chat.