### PR TITLE
Fix creation of Chat when AccessManager enabled on PubNub keys.

### DIFF
--- a/api/pubnub-chat.api
+++ b/api/pubnub-chat.api
@@ -11,6 +11,7 @@ public final class com/pubnub/chat/MediatorsKt {
 }
 
 public final class com/pubnub/chat/Mediators_jvmKt {
-	public static final fun init (Lcom/pubnub/chat/Chat$Companion;Lcom/pubnub/chat/config/ChatConfiguration;Lcom/pubnub/api/v2/PNConfiguration;)Lcom/pubnub/kmp/PNFuture;
+	public static final fun init (Lcom/pubnub/chat/Chat$Companion;Lcom/pubnub/chat/config/ChatConfiguration;Lcom/pubnub/api/v2/PNConfiguration;Ljava/lang/String;)Lcom/pubnub/kmp/PNFuture;
+	public static synthetic fun init$default (Lcom/pubnub/chat/Chat$Companion;Lcom/pubnub/chat/config/ChatConfiguration;Lcom/pubnub/api/v2/PNConfiguration;Ljava/lang/String;ILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ POM_DEVELOPER_URL=support@pubnub.com
 IOS_SIMULATOR_ID=iPhone 15 Pro
 SWIFT_PATH=pubnub-kotlin/swift
 
-ENABLE_TARGET_JS=true
+ENABLE_TARGET_JS=false
 ENABLE_TARGET_IOS_OTHER=false
 ENABLE_TARGET_IOS_SIMULATOR_ARM64=true
 # alternatively (e.g. for release):

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
@@ -505,7 +505,12 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
         val mentionedUsers =
             mapOf<Int, MessageMentionedUser>(mentionedPosition to MessageMentionedUser("user01Id", "user01Name"))
         val referencedChannels =
-            mapOf<Int, MessageReferencedChannel>(referencedPosition to MessageReferencedChannel(id = "channel01Id", name = "channel01Name"))
+            mapOf<Int, MessageReferencedChannel>(
+                referencedPosition to MessageReferencedChannel(
+                    id = "channel01Id",
+                    name = "channel01Name"
+                )
+            )
         val tt = channel01.sendText(
             text = messageText,
             ttl = 60,
@@ -643,22 +648,23 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
             var streamMessageReportsCloseable: AutoCloseable? = null
 
             pubnub.awaitSubscribe(listOf("PUBNUB_INTERNAL_MODERATION_${channel01.id}")) {
-                streamMessageReportsCloseable = channel01.streamMessageReports { reportEvent: Event<EventContent.Report> ->
-                    try {
-                        // we need to have try/catch here because assertion error will not cause test to fail
-                        numberOfReports.incrementAndGet()
-                        val reportReason = reportEvent.payload.reason
-                        assertTrue(reportReason == reason01 || reportReason == reason02)
-                        assertEquals(messageText, reportEvent.payload.text)
-                        assertTrue(reportEvent.payload.reportedMessageChannelId?.contains(INTERNAL_MODERATION_PREFIX)!!)
-                        assertTrue(reportEvent.channelId.contains(INTERNAL_MODERATION_PREFIX))
-                        if (numberOfReports.value == 2) {
-                            assertionErrorInCallback.complete(null)
+                streamMessageReportsCloseable =
+                    channel01.streamMessageReports { reportEvent: Event<EventContent.Report> ->
+                        try {
+                            // we need to have try/catch here because assertion error will not cause test to fail
+                            numberOfReports.incrementAndGet()
+                            val reportReason = reportEvent.payload.reason
+                            assertTrue(reportReason == reason01 || reportReason == reason02)
+                            assertEquals(messageText, reportEvent.payload.text)
+                            assertTrue(reportEvent.payload.reportedMessageChannelId?.contains(INTERNAL_MODERATION_PREFIX)!!)
+                            assertTrue(reportEvent.channelId.contains(INTERNAL_MODERATION_PREFIX))
+                            if (numberOfReports.value == 2) {
+                                assertionErrorInCallback.complete(null)
+                            }
+                        } catch (e: AssertionError) {
+                            assertionErrorInCallback.complete(e)
                         }
-                    } catch (e: AssertionError) {
-                        assertionErrorInCallback.complete(e)
                     }
-                }
             }
 
             // report messages
@@ -746,7 +752,10 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
             val elements = MessageDraftImpl.getMessageElements(message.await().text)
 
             assertEquals(
-                listOf(MessageElement.PlainText("Some text with a "), MessageElement.Link("mention", MentionTarget.User("someUser"))),
+                listOf(
+                    MessageElement.PlainText("Some text with a "),
+                    MessageElement.Link("mention", MentionTarget.User("someUser"))
+                ),
                 elements
             )
         }

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChatIntegrationTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChatIntegrationTest.kt
@@ -4,6 +4,8 @@ import com.pubnub.api.PubNubException
 import com.pubnub.api.enums.PNPushEnvironment
 import com.pubnub.api.enums.PNPushType
 import com.pubnub.api.models.consumer.PNPublishResult
+import com.pubnub.api.models.consumer.access_manager.v3.ChannelGrant
+import com.pubnub.api.models.consumer.access_manager.v3.UUIDGrant
 import com.pubnub.api.models.consumer.objects.membership.ChannelMembershipInput
 import com.pubnub.api.models.consumer.objects.membership.PNChannelMembership
 import com.pubnub.api.v2.callbacks.Result
@@ -34,6 +36,7 @@ import com.pubnub.chat.types.MessageMentionedUsers
 import com.pubnub.chat.types.ThreadMentionData
 import com.pubnub.kmp.CustomObject
 import com.pubnub.kmp.createCustomObject
+import com.pubnub.kmp.createPubNub
 import com.pubnub.test.await
 import com.pubnub.test.randomString
 import com.pubnub.test.test
@@ -52,6 +55,31 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class ChatIntegrationTest : BaseChatIntegrationTest() {
+    @Test
+    fun initializeShouldThrow403WhenPamEnableAndNoToken() = runTest {
+        val exception = assertFailsWith<PubNubException> {
+            chatPamClient.initialize().await()
+        }
+
+        assertEquals(403, exception.statusCode)
+    }
+
+    @Test
+    fun initializeShouldPassWhenPamEnableAndTokenProvided() = runTest {
+        pubnubPamClient = createPubNub(configPamClient)
+        val token = chatPamServer.pubNub.grantToken(
+            ttl = 1,
+            channels = listOf(ChannelGrant.name(get = true, name = "any", read = true, write = true, manage = true)), // get = true
+            uuids = listOf(UUIDGrant.id(id = pubnubPamClient.configuration.userId.value, get = true, update = true)) // this is important
+        ).await().token
+
+        pubnubPamClient.setToken(token)
+        chatPamClient = ChatImpl(ChatConfiguration(), pubnubPamClient)
+        val initializeChat = chatPamClient.initialize().await()
+
+        assertEquals(token, initializeChat.pubNub.getToken())
+    }
+
     @Test
     fun createUser() = runTest {
         val user = chat.createUser(someUser).await()

--- a/src/jvmMain/kotlin/com/pubnub/chat/mediators.jvm.kt
+++ b/src/jvmMain/kotlin/com/pubnub/chat/mediators.jvm.kt
@@ -1,15 +1,27 @@
 package com.pubnub.chat
 
+import com.pubnub.api.PubNub
 import com.pubnub.api.v2.PNConfiguration
 import com.pubnub.chat.config.ChatConfiguration
 import com.pubnub.chat.internal.ChatImpl
 import com.pubnub.chat.internal.PUBNUB_CHAT_VERSION
 import com.pubnub.kmp.PNFuture
 
-fun Chat.Companion.init(chatConfiguration: ChatConfiguration, pubNubConfiguration: PNConfiguration): PNFuture<Chat> {
+/**
+ * Initializes an instance of [Chat] with the specified [ChatConfiguration] and [PNConfiguration].
+ * A [token] should be provided when AccessManager is enabled on PubNub keys.
+ *
+ * @param chatConfiguration The configuration for initializing the [Chat] instance.
+ * @param pubNubConfiguration The base PubNub configuration to be used.
+ * @param token Optional authentication token for the PubNub client. Should be provided when AccessManager is enabled on PubNub keys.
+ * @return A [PNFuture] containing the initialized [Chat] instance.
+ */
+fun Chat.Companion.init(chatConfiguration: ChatConfiguration, pubNubConfiguration: PNConfiguration, token: String? = null): PNFuture<Chat> {
     val builder = PNConfiguration.builder(pubNubConfiguration)
     builder.pnsdkSuffixes = pubNubConfiguration.pnsdkSuffixes.toMutableMap().apply {
         put("chat-sdk", "CA-JVM/$PUBNUB_CHAT_VERSION")
     }
-    return ChatImpl(chatConfiguration, com.pubnub.api.PubNub.create(builder.build())).initialize()
+    val pubNub = PubNub.create(builder.build()).apply { setToken(token) }
+
+    return ChatImpl(chatConfiguration, pubNub).initialize()
 }

--- a/src/jvmMain/kotlin/com/pubnub/chat/mediators.jvm.kt
+++ b/src/jvmMain/kotlin/com/pubnub/chat/mediators.jvm.kt
@@ -14,6 +14,8 @@ import com.pubnub.kmp.PNFuture
  * @param chatConfiguration The configuration for initializing the [Chat] instance.
  * @param pubNubConfiguration The base PubNub configuration to be used.
  * @param token Optional authentication token for the PubNub client. Should be provided when AccessManager is enabled on PubNub keys.
+ * You can generate it using [PubNub.grantToken] method using server PubNub(pubnub initialize with secretKey).
+ * When initializing Chat as server Chat(PNConfiguration contain secretKey) token in not needed.
  * @return A [PNFuture] containing the initialized [Chat] instance.
  */
 fun Chat.Companion.init(chatConfiguration: ChatConfiguration, pubNubConfiguration: PNConfiguration, token: String? = null): PNFuture<Chat> {

--- a/src/jvmTest/kotlin/compubnub/chat/ChatIntegrationTest.kt
+++ b/src/jvmTest/kotlin/compubnub/chat/ChatIntegrationTest.kt
@@ -68,7 +68,7 @@ class ChatIntegrationTest : BaseIntegrationTest() {
     }
 
     @Test
-    fun conInitializeChatWithCustomPayloadAndCustomActions() {
+    fun canInitializeChatWithCustomPayloadAndCustomActions() {
         var chat: Chat
         val customPayloads: CustomPayloads = CustomPayloads(
             getMessagePublishBody = { content, channelId, defaultMessagePublishBody ->

--- a/src/jvmTest/kotlin/compubnub/chat/ChatIntegrationTest.kt
+++ b/src/jvmTest/kotlin/compubnub/chat/ChatIntegrationTest.kt
@@ -1,10 +1,13 @@
 package compubnub.chat
 
+import com.pubnub.api.PubNub
 import com.pubnub.api.PubNubException
 import com.pubnub.api.UserId
 import com.pubnub.api.asList
 import com.pubnub.api.asMap
 import com.pubnub.api.asString
+import com.pubnub.api.models.consumer.access_manager.v3.ChannelGrant
+import com.pubnub.api.models.consumer.access_manager.v3.UUIDGrant
 import com.pubnub.api.v2.PNConfiguration
 import com.pubnub.api.v2.callbacks.Result
 import com.pubnub.chat.Chat
@@ -14,9 +17,14 @@ import com.pubnub.chat.config.LogLevel
 import com.pubnub.chat.init
 import com.pubnub.chat.types.EventContent
 import com.pubnub.chat.types.File
+import com.pubnub.test.BaseIntegrationTest
+import com.pubnub.test.await
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
-class ChatIntegrationTest {
+class ChatIntegrationTest : BaseIntegrationTest() {
     @Test
     fun canInitializeChatWithLogLevel() {
         val chatConfig = ChatConfiguration(logLevel = LogLevel.OFF)
@@ -30,6 +38,33 @@ class ChatIntegrationTest {
                 println("Exception initialising chat: ${exception.message}")
             }
         }
+    }
+
+    @Test
+    fun shouldReceiveExceptionWhenInitializingChatWithoutValidTokenWhenPamEnabled() = runTest {
+        val exception: PubNubException = assertFailsWith<PubNubException> {
+            Chat.init(ChatConfiguration(), configPamClient).await()
+        }
+
+        assertEquals(403, exception.statusCode)
+    }
+
+    @Test
+    fun canInitializeChatWhenPamEnableAndTokenSet() = runTest {
+        val clientPubNub = PubNub.create(configPamClient)
+        val clientUserId = clientPubNub.configuration.userId.value
+
+        val serverChat = Chat.init(ChatConfiguration(), configPamServer).await()
+        val token = serverChat.pubNub.grantToken(
+            ttl = 1,
+            channels = listOf(ChannelGrant.name(get = true, name = "anyChannelForNow")),
+            uuids = listOf(UUIDGrant.id(id = clientUserId, get = true, update = true)) // this is important
+        ).await().token
+
+        val clientChat = Chat.init(ChatConfiguration(), configPamClient, token).await()
+
+        assertEquals(clientUserId, clientChat.currentUser.id)
+        assertEquals(clientChat.pubNub.getToken(), token)
     }
 
     @Test


### PR DESCRIPTION
Chat.init() calls initialize() which calls pubNub.getUUIDMetadata that fails when AccessManager is enabled and token is not set for PubNub instance that is created inside Chat.init()

Token should be granted for pubNub.configuration.userId.value
        val token = serverChat.pubNub.grantToken(
            ttl = 1,
            channels = listOf(ChannelGrant.name(get = true, name = "anyChannelForNow")),
            uuids = listOf(UUIDGrant.id(id = pubNub.configuration.userId.value, get = true, update = true)) // this is important
        ).await().token