### PR TITLE
Removed authToken from init method.

### DIFF
--- a/api/pubnub-chat.api
+++ b/api/pubnub-chat.api
@@ -11,7 +11,6 @@ public final class com/pubnub/chat/MediatorsKt {
 }
 
 public final class com/pubnub/chat/Mediators_jvmKt {
-	public static final fun init (Lcom/pubnub/chat/Chat$Companion;Lcom/pubnub/chat/config/ChatConfiguration;Lcom/pubnub/api/v2/PNConfiguration;Ljava/lang/String;)Lcom/pubnub/kmp/PNFuture;
-	public static synthetic fun init$default (Lcom/pubnub/chat/Chat$Companion;Lcom/pubnub/chat/config/ChatConfiguration;Lcom/pubnub/api/v2/PNConfiguration;Ljava/lang/String;ILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;
+	public static final fun init (Lcom/pubnub/chat/Chat$Companion;Lcom/pubnub/chat/config/ChatConfiguration;Lcom/pubnub/api/v2/PNConfiguration;)Lcom/pubnub/kmp/PNFuture;
 }
 

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
@@ -1,6 +1,5 @@
 package com.pubnub.integration
 
-import com.pubnub.api.PubNubException
 import com.pubnub.api.models.consumer.objects.PNMemberKey
 import com.pubnub.api.models.consumer.objects.PNSortKey
 import com.pubnub.chat.Channel
@@ -21,7 +20,6 @@ import com.pubnub.chat.types.GetEventsHistoryResult
 import com.pubnub.chat.types.JoinResult
 import com.pubnub.chat.types.MessageMentionedUser
 import com.pubnub.chat.types.MessageReferencedChannel
-import com.pubnub.chat.user.GetUsersResponse
 import com.pubnub.kmp.createCustomObject
 import com.pubnub.test.await
 import com.pubnub.test.randomString
@@ -357,9 +355,9 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
         chat.createUser(UserImpl(chat, userId)).await()
         chat.deleteUser(id = userId, soft = true).await()
 
-        val getUsersResponse = chat.getUsers(filter = "id == '${userId}' && status=='deleted'").await()
-        assertEquals(userId, getUsersResponse.users.first().id)
+        val getUsersResponse = chat.getUsers(filter = "id == '$userId' && status=='deleted'").await()
 
+        assertEquals(userId, getUsersResponse.users.first().id)
         assertEquals("deleted", getUsersResponse.users.first().status)
 
         // clean

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
@@ -357,14 +357,10 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
         chat.createUser(UserImpl(chat, userId)).await()
         chat.deleteUser(id = userId, soft = true).await()
 
-        chat.getUsers(filter = "status=='deleted'").async { result ->
-            result.onSuccess { getUsersResponse: GetUsersResponse ->
-                assertEquals(userId, getUsersResponse.users.first().id)
-                assertEquals("deleted", getUsersResponse.users.first().status)
-            }.onFailure { e: PubNubException ->
-                throw IllegalStateException(e)
-            }
-        }
+        val getUsersResponse = chat.getUsers(filter = "id == '${userId}' && status=='deleted'").await()
+        assertEquals(userId, getUsersResponse.users.first().id)
+
+        assertEquals("deleted", getUsersResponse.users.first().status)
 
         // clean
         try {

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChannelTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChannelTest.kt
@@ -97,7 +97,7 @@ class ChannelTest : BaseTest() {
         every { chat.pubNub } returns pubNub
         val timerManager = createTimerManager()
         every { chat.timerManager } returns timerManager
-        every { pubNub.configuration } returns createPNConfiguration(UserId("demo"), "demo", "demo")
+        every { pubNub.configuration } returns createPNConfiguration(UserId("demo"), "demo", "demo", authToken = null)
         objectUnderTest = createChannel(type)
     }
 

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChatTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChatTest.kt
@@ -131,7 +131,7 @@ class ChatTest : BaseTest() {
 
     @BeforeTest
     fun setUp() {
-        pnConfiguration = createPNConfiguration(UserId(userId), subscribeKey, publishKey)
+        pnConfiguration = createPNConfiguration(UserId(userId), subscribeKey, publishKey, authToken = null)
         every { pubnub.configuration } returns pnConfiguration
         chatConfig = ChatConfiguration(
             typingTimeout = 2000.milliseconds

--- a/src/jvmMain/kotlin/com/pubnub/chat/mediators.jvm.kt
+++ b/src/jvmMain/kotlin/com/pubnub/chat/mediators.jvm.kt
@@ -9,21 +9,17 @@ import com.pubnub.kmp.PNFuture
 
 /**
  * Initializes an instance of [Chat] with the specified [ChatConfiguration] and [PNConfiguration].
- * A [token] should be provided when AccessManager is enabled on PubNub keys.
  *
  * @param chatConfiguration The configuration for initializing the [Chat] instance.
  * @param pubNubConfiguration The base PubNub configuration to be used.
- * @param token Optional authentication token for the PubNub client. Should be provided when AccessManager is enabled on PubNub keys.
- * You can generate it using [PubNub.grantToken] method using server PubNub(pubnub initialize with secretKey).
- * When initializing Chat as server Chat(PNConfiguration contain secretKey) token in not needed.
  * @return A [PNFuture] containing the initialized [Chat] instance.
  */
-fun Chat.Companion.init(chatConfiguration: ChatConfiguration, pubNubConfiguration: PNConfiguration, token: String? = null): PNFuture<Chat> {
+fun Chat.Companion.init(chatConfiguration: ChatConfiguration, pubNubConfiguration: PNConfiguration): PNFuture<Chat> {
     val builder = PNConfiguration.builder(pubNubConfiguration)
     builder.pnsdkSuffixes = pubNubConfiguration.pnsdkSuffixes.toMutableMap().apply {
         put("chat-sdk", "CA-JVM/$PUBNUB_CHAT_VERSION")
     }
-    val pubNub = PubNub.create(builder.build()).apply { setToken(token) }
+    val pubNub = PubNub.create(builder.build())
 
     return ChatImpl(chatConfiguration, pubNub).initialize()
 }


### PR DESCRIPTION
It is not needed any more here because it can be provided when creating PNConfiguration.

 val configPamClient: PNConfiguration = PNConfiguration.builder(UserId(clientUserId), Keys.pamSubKey) {
    publishKey = Keys.pamPubKey
    logVerbosity = PNLogVerbosity.BODY
    authToken = token
 }.build()