### PR TITLE
Remove kotlinx.datetime dependency

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Build and run tests
         run: |
-          ./gradlew check
+          ./gradlew check -i
         env:
           SDK_PUB_KEY: ${{ secrets.SDK_PUB_KEY }}
           SDK_SUB_KEY: ${{ secrets.SDK_SUB_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("com.pubnub:pubnub-kotlin-test")
+                implementation(libs.pubnub.kotlin.test)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,24 +4,16 @@ kotlin = "2.0.21"
 vanniktech = "0.29.0"
 ktlint = "12.1.0"
 dokka = "1.9.20"
-kotlinx_datetime = "0.6.0"
-kotlinx_coroutines = "1.8.1"
 kotlinx_serialization = "1.7.1"
-pubnub = "10.1.0"
+pubnub = "10.2.0"
 
 [libraries]
 pubnub-kotlin-api = { module = "com.pubnub:pubnub-kotlin-api", version.ref = "pubnub" }
-pubnub-kotlin-impl = { module = "com.pubnub:pubnub-kotlin-impl", version.ref = "pubnub" }
 pubnub-kotlin = { module = "com.pubnub:pubnub-kotlin", version.ref = "pubnub" }
 pubnub-kotlin-test = { module = "com.pubnub:pubnub-kotlin-test", version.ref = "pubnub" }
-#slf4j = { module = "org.slf4j:slf4j-api", version = "1.7.36" }
-#cbor = { module = "co.nstant.in:cbor", version = "0.9" }
-#jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.1.0" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version = "0.25.0" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx_serialization" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx_datetime"}
 touchlab-kermit = { module = "co.touchlab:kermit", version = "2.0.4" }
-diff-match-patch = { module = "org.bitbucket.cowwoc:diff-match-patch", version = "1.2" }
 
 ## tests
 #logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/pubnub-3p-diff-match-patch/api/pubnub-3p-diff-match-patch.api
+++ b/pubnub-3p-diff-match-patch/api/pubnub-3p-diff-match-patch.api
@@ -3,7 +3,7 @@ public final class name/fraser/neil/plaintext/DiffMatchPatch {
 	public fun <init> ()V
 	public fun <init> (FSFIFS)V
 	public synthetic fun <init> (FSFIFSILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun diff_bisect (Ljava/lang/String;Ljava/lang/String;J)Ljava/util/List;
+	public final fun diff_bisect-UpJHN0k (Ljava/lang/String;Ljava/lang/String;J)Ljava/util/List;
 	public final fun diff_charsToLines (Ljava/util/List;Ljava/util/List;)V
 	public final fun diff_cleanupEfficiency (Ljava/util/List;)V
 	public final fun diff_cleanupMerge (Ljava/util/List;)V

--- a/pubnub-3p-diff-match-patch/build.gradle.kts
+++ b/pubnub-3p-diff-match-patch/build.gradle.kts
@@ -12,11 +12,6 @@ mavenPublishing {
 
 kotlin {
     sourceSets {
-        commonMain {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
-            }
-        }
         commonTest {
             dependencies {
                 implementation(kotlin("test"))

--- a/pubnub-chat-impl/build.gradle.kts
+++ b/pubnub-chat-impl/build.gradle.kts
@@ -42,7 +42,6 @@ kotlin {
                 implementation(project(":pubnub-chat-api"))
                 implementation(project(":pubnub-3p-diff-match-patch"))
                 implementation(libs.pubnub.kotlin.api)
-                implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.serialization.core)
                 implementation(libs.kotlinx.atomicfu)
                 implementation(libs.touchlab.kermit)

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/ChatImpl.kt
@@ -31,6 +31,8 @@ import com.pubnub.api.models.consumer.pubsub.PNEvent
 import com.pubnub.api.models.consumer.push.PNPushAddChannelResult
 import com.pubnub.api.models.consumer.push.PNPushListProvisionsResult
 import com.pubnub.api.models.consumer.push.PNPushRemoveChannelResult
+import com.pubnub.api.utils.Clock
+import com.pubnub.api.utils.Instant
 import com.pubnub.api.v2.callbacks.Result
 import com.pubnub.chat.Channel
 import com.pubnub.chat.Chat
@@ -109,8 +111,6 @@ import com.pubnub.kmp.createEventListener
 import com.pubnub.kmp.then
 import com.pubnub.kmp.thenAsync
 import encodeForSending
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.seconds
 

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/UserImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/UserImpl.kt
@@ -11,6 +11,8 @@ import com.pubnub.api.models.consumer.objects.membership.PNChannelMembershipArra
 import com.pubnub.api.models.consumer.objects.uuid.PNUUIDMetadata
 import com.pubnub.api.models.consumer.pubsub.objects.PNDeleteUUIDMetadataEventMessage
 import com.pubnub.api.models.consumer.pubsub.objects.PNSetUUIDMetadataEventMessage
+import com.pubnub.api.utils.Clock
+import com.pubnub.api.utils.Instant
 import com.pubnub.api.utils.PatchValue
 import com.pubnub.api.v2.callbacks.Result
 import com.pubnub.chat.Channel
@@ -31,8 +33,6 @@ import com.pubnub.kmp.asFuture
 import com.pubnub.kmp.catch
 import com.pubnub.kmp.createEventListener
 import com.pubnub.kmp.then
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import tryLong
 
 data class UserImpl(

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/BaseChannel.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/BaseChannel.kt
@@ -24,6 +24,8 @@ import com.pubnub.api.models.consumer.pubsub.objects.PNDeleteChannelMetadataEven
 import com.pubnub.api.models.consumer.pubsub.objects.PNObjectEventResult
 import com.pubnub.api.models.consumer.pubsub.objects.PNSetChannelMetadataEventMessage
 import com.pubnub.api.models.consumer.push.payload.PushPayloadHelper
+import com.pubnub.api.utils.Clock
+import com.pubnub.api.utils.Instant
 import com.pubnub.api.utils.PatchValue
 import com.pubnub.api.v2.callbacks.Result
 import com.pubnub.api.v2.subscriptions.SubscriptionOptions
@@ -95,8 +97,6 @@ import encodeForSending
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import tryLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ChannelImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ChannelImpl.kt
@@ -1,13 +1,13 @@
 package com.pubnub.chat.internal.channel
 
 import com.pubnub.api.models.consumer.objects.channel.PNChannelMetadata
+import com.pubnub.api.utils.Clock
 import com.pubnub.chat.Channel
 import com.pubnub.chat.Message
 import com.pubnub.chat.internal.ChatInternal
 import com.pubnub.chat.internal.DELETED
 import com.pubnub.chat.internal.message.MessageImpl
 import com.pubnub.chat.types.ChannelType
-import kotlinx.datetime.Clock
 
 data class ChannelImpl(
     override val chat: ChatInternal,

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ThreadChannelImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ThreadChannelImpl.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.pubnub.api.models.consumer.PNPublishResult
 import com.pubnub.api.models.consumer.message_actions.PNMessageAction
 import com.pubnub.api.models.consumer.objects.channel.PNChannelMetadata
+import com.pubnub.api.utils.Clock
 import com.pubnub.chat.Channel
 import com.pubnub.chat.Message
 import com.pubnub.chat.ThreadChannel
@@ -25,7 +26,6 @@ import com.pubnub.kmp.asFuture
 import com.pubnub.kmp.awaitAll
 import com.pubnub.kmp.then
 import com.pubnub.kmp.thenAsync
-import kotlinx.datetime.Clock
 
 data class ThreadChannelImpl(
     override val parentMessage: Message,

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/integration/ChannelIntegrationTest.kt
@@ -26,6 +26,7 @@ import com.pubnub.kmp.createCustomObject
 import com.pubnub.test.await
 import com.pubnub.test.randomString
 import com.pubnub.test.test
+import delayForHistory
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
@@ -44,10 +45,12 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
     @Test
     fun getPinnedMessage() = runTest {
         val timetoken = channel01.sendText("Text text text").await()
+        delayForHistory()
         val message = channel01.getMessage(timetoken.timetoken).await()!!
 
         val updatedChannel = channel01.pinMessage(message).await()
         assertEquals(timetoken.timetoken.toString(), updatedChannel.custom?.get(PINNED_MESSAGE_TIMETOKEN))
+        delayForHistory()
         val pinnedMessage = updatedChannel.getPinnedMessage().await()
 
         assertNotNull(pinnedMessage)
@@ -387,6 +390,7 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
 
         val channel = chat.createDirectConversation(user2).await().channel
         channel.sendText("text1").await().timetoken
+        delayForHistory()
         chat.markAllMessagesAsRead().await()
 
         val tt = channel.sendText("text2").await().timetoken
@@ -488,8 +492,7 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
         val messageText = "some text"
         val tt = channel01.sendText(text = messageText, ttl = 60).await().timetoken
 
-        delayInMillis(1000)
-
+        delayForHistory()
         val message = channel01.getMessage(tt).await()
         assertEquals(messageText, message?.text)
         assertEquals(tt, message?.timetoken)
@@ -516,8 +519,7 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
             referencedChannels = referencedChannels
         ).await().timetoken
 
-        delayInMillis(1500)
-
+        delayForHistory()
         val message = channel01.getMessage(tt).await()
         val actualMentionedUsers: Map<Int, MessageMentionedUser>? = message?.mentionedUsers
         val actualMentionPosition = actualMentionedUsers?.keys?.first()
@@ -604,7 +606,7 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
     fun can_getMessageReportsHistory() = runTest {
         val pnPublishResult = channel01.sendText(text = "message1").await()
         val timetoken = pnPublishResult.timetoken
-        delayInMillis(250)
+        delayForHistory()
         val message = channel01.getMessage(timetoken).await()!!
 
         // report messages
@@ -614,6 +616,7 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
         message.report(reason02).await()
 
         // getMessageReport
+        delayForHistory()
         val eventsHistoryResult: GetEventsHistoryResult = channel01.getMessageReportsHistory().await()
         assertEquals(2, eventsHistoryResult.events.size)
 
@@ -640,6 +643,7 @@ class ChannelIntegrationTest : BaseChatIntegrationTest() {
         val messageText = "message1"
         val pnPublishResult = channel01.sendText(text = messageText).await()
         val timetoken = pnPublishResult.timetoken
+        delayForHistory()
         val message = channel01.getMessage(timetoken).await()!!
         val assertionErrorInCallback = CompletableDeferred<AssertionError?>()
 

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/internal/testutils.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/internal/testutils.kt
@@ -1,0 +1,8 @@
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.seconds
+
+suspend fun delayForHistory() = withContext(Dispatchers.Default) {
+    delay(1.seconds)
+}

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChannelTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChannelTest.kt
@@ -18,6 +18,8 @@ import com.pubnub.api.models.consumer.objects.PNSortKey
 import com.pubnub.api.models.consumer.objects.channel.PNChannelMetadata
 import com.pubnub.api.models.consumer.objects.channel.PNChannelMetadataResult
 import com.pubnub.api.models.consumer.objects.member.PNUUIDDetailsLevel
+import com.pubnub.api.utils.Clock
+import com.pubnub.api.utils.Instant
 import com.pubnub.api.utils.PatchValue
 import com.pubnub.api.v2.callbacks.Consumer
 import com.pubnub.api.v2.callbacks.Result
@@ -58,8 +60,6 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ThreadChannelTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ThreadChannelTest.kt
@@ -1,5 +1,6 @@
 package com.pubnub.kmp
 
+import com.pubnub.api.utils.Clock
 import com.pubnub.api.v2.callbacks.Result
 import com.pubnub.chat.Channel
 import com.pubnub.chat.Message
@@ -12,7 +13,6 @@ import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
-import kotlinx.datetime.Clock
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/utils/ExponentialRateLimiterTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/utils/ExponentialRateLimiterTest.kt
@@ -1,5 +1,7 @@
 package com.pubnub.kmp.utils
 
+import com.pubnub.api.utils.Clock
+import com.pubnub.api.utils.Instant
 import com.pubnub.chat.internal.timer.createTimerManager
 import com.pubnub.chat.internal.utils.ExponentialRateLimiter
 import com.pubnub.kmp.PNFuture
@@ -10,8 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.time.Duration


### PR DESCRIPTION
Following the changes in `pubnub-kotlin`, use the `com.pubnub.api` version of `Instant` and `Clock` to reduce JS size.