### PR TITLE
[JS] MessageDraftV2 + remove `crypto` usage

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: kmp-chat
-version: 0.9.0
+version: 0.9.2
 schema: 1
 scm: github.com/pubnub/kmp-chat
 sdks:
@@ -21,8 +21,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: maven
-              package-name: pubnub-chat-0.9.0
-              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-chat/0.9.0/
+              package-name: pubnub-chat-0.9.2
+              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-chat/0.9.2/
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -77,6 +77,17 @@ sdks:
                   license-url: https://github.com/pubnub/kotlin/blob/master/LICENSE
                   is-required: Required
 changelog:
+  - date: 2024-12-12
+    version: v0.9.2
+    changes:
+      - type: feature
+        text: "Lock moderated messages from editing ."
+      - type: bug
+        text: "Wrong user suggestion source for message draft created on ThreadChannel."
+      - type: bug
+        text: "Wrong type of last user activity time stored on server (precision)."
+      - type: improvement
+        text: "Moderation events are now sent to a channel prefixed with `PUBNUB_INTERNAL_MODERATION.`."
   - date: 2024-11-06
     version: v0.9.0
     changes:

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "PubNubChatRemoteBinaryPackage",
-      url: "https://github.com/pubnub/kmp-chat/releases/download/kotlin-v0.9.0/PubNubChat.xcframework.zip",
-      checksum: "e043957bd849c7243085368c0e64607cec6dc2e8db6c863f1a80c025d11f6497"
+      url: "https://github.com/pubnub/kmp-chat/releases/download/kotlin-0.9.2/PubNubChat.xcframework.zip",
+      checksum: "ba90004881639c1ae7e05cf93d68554a77717f8f7c89515a1894cce03a557122"
     )
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "PubNubChatRemoteBinaryPackage",
-      url: "https://github.com/pubnub/kmp-chat/releases/download/kotlin-0.9.2/PubNubChat.xcframework.zip",
+      url: "https://github.com/pubnub/kmp-chat/releases/download/kotlin-v0.9.2/PubNubChat.xcframework.zip",
       checksum: "ba90004881639c1ae7e05cf93d68554a77717f8f7c89515a1894cce03a557122"
     )
   ]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
       <dependency>
          <groupId>com.pubnub</groupId>
          <artifactId>pubnub-chat</artifactId>
-         <version>0.9.0</version>
+         <version>0.9.2</version>
       </dependency>
       ```
 

--- a/build-logic/gradle-plugins/src/main/kotlin/com/pubnub/gradle/PubNubKotlinMultiplatformPlugin.kt
+++ b/build-logic/gradle-plugins/src/main/kotlin/com/pubnub/gradle/PubNubKotlinMultiplatformPlugin.kt
@@ -2,6 +2,7 @@ package com.pubnub.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -38,9 +39,16 @@ class PubNubKotlinMultiplatformPlugin : Plugin<Project> {
                         }
 
                         pod("PubNubSwift") {
-//                            val swiftPath = project.findProperty("SWIFT_PATH") as? String ?: "swift"
-//                            source = path(rootProject.file(swiftPath))
-                            version = "8.1.0"
+                            val swiftPath = project.findProperty("SWIFT_PATH") as? String
+                            if (swiftPath != null) {
+                                source = path(rootProject.file(swiftPath))
+                            } else {
+                                version = project.rootProject
+                                    .extensions
+                                    .getByType(VersionCatalogsExtension::class.java)
+                                    .named("libs")
+                                    .findVersion("pubnub.swift").get().requiredVersion
+                            }
                             moduleName = "PubNubSDK"
                             extraOpts += listOf("-compiler-option", "-fmodules")
                         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,6 @@ kotlin {
 
             compilerOptions {
                 target.set("es2015")
-                generateTypeScriptDefinitions()
             }
             binaries.library()
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,6 @@ kotlin {
 
             compilerOptions {
                 target.set("es2015")
-//                moduleKind.set(JsModuleKind.MODULE_UMD)
             }
             binaries.library()
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
 
             compilerOptions {
                 target.set("es2015")
+                generateTypeScriptDefinitions()
             }
             binaries.library()
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=false
 GROUP=com.pubnub
 POM_PACKAGING=jar
-VERSION_NAME=0.9.1
+VERSION_NAME=0.9.2
 
 POM_NAME=PubNub Chat SDK
 POM_DESCRIPTION=This SDK offers a set of handy methods to create your own feature-rich chat or add a chat to your existing application.

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ POM_DEVELOPER_NAME=PubNub
 POM_DEVELOPER_URL=support@pubnub.com
 
 IOS_SIMULATOR_ID=iPhone 15 Pro
-SWIFT_PATH=pubnub-kotlin/swift
+#SWIFT_PATH=../swift
 
 ENABLE_TARGET_JS=true
 ENABLE_TARGET_IOS_OTHER=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ dokka = "1.9.20"
 kotlinx_serialization = "1.7.3"
 kotlinx_coroutines = "1.9.0"
 pubnub = "10.3.1"
+pubnub_swift = "8.2.2"
 
 [libraries]
 pubnub-kotlin-api = { module = "com.pubnub:pubnub-kotlin-api", version.ref = "pubnub" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ ktlint = "12.1.0"
 dokka = "1.9.20"
 kotlinx_serialization = "1.7.3"
 kotlinx_coroutines = "1.9.0"
-pubnub = "10.3.0"
+pubnub = "10.3.1"
 
 [libraries]
 pubnub-kotlin-api = { module = "com.pubnub:pubnub-kotlin-api", version.ref = "pubnub" }

--- a/js-chat/main.mjs
+++ b/js-chat/main.mjs
@@ -1,4 +1,8 @@
 export * from "../build/dist/js/productionLibrary/pubnub-chat.mjs"
 export const INTERNAL_MODERATION_PREFIX = "PUBNUB_INTERNAL_MODERATION_"
+export const MESSAGE_THREAD_ID_PREFIX = "PUBNUB_INTERNAL_THREAD";
+export const INTERNAL_ADMIN_CHANNEL = "PUBNUB_INTERNAL_ADMIN_CHANNEL";
+export const ERROR_LOGGER_KEY_PREFIX = "PUBNUB_INTERNAL_ERROR_LOGGER";
+
 import PubNub from "pubnub"
 export let CryptoModule = PubNub.CryptoModule

--- a/js-chat/tests/message-draft-v2.test.ts
+++ b/js-chat/tests/message-draft-v2.test.ts
@@ -1,0 +1,432 @@
+import { Channel, Chat } from "../dist"
+import {
+  createChatInstance,
+  createRandomChannel,
+  createRandomUser,
+  renderMessagePart,
+} from "./utils"
+import { jest } from "@jest/globals"
+
+describe("MessageDraft", function () {
+  jest.retryTimes(2)
+  let chat: Chat
+  let channel: Channel
+  let messageDraft
+
+  beforeAll(async () => {
+    chat = await createChatInstance()
+  })
+
+  beforeEach(async () => {
+    channel = await createRandomChannel()
+    messageDraft = channel.createMessageDraftV2({ userSuggestionSource: "global" })
+  })
+
+  test.only("should mention 2 users", async () => {
+    const [user1, user2] = await Promise.all([createRandomUser(), createRandomUser()])
+
+    messageDraft.update("Hello @user1 and @user2")
+    messageDraft.addMention(6, 6, "mention", user1.id)
+    messageDraft.addMention(17, 6, "mention", user2.id)
+    const messagePreview = messageDraft.getMessagePreview()
+    expect(messagePreview.length).toBe(4)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("mention")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("mention")
+    expect(messageDraft.value).toBe(`Hello @user1 and @user2`)
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello @user1 and @user2`
+    )
+    await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
+  })
+
+  test("should mention 2 - 3 users next to each other", async () => {
+    const [user1, user2, user3] = await Promise.all([
+      createRandomUser(),
+      createRandomUser(),
+      createRandomUser(),
+    ])
+
+    messageDraft.onChange("Hello @user1 @user2 @user3")
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addMentionedUser(user2, 1)
+    messageDraft.addMentionedUser(user3, 2)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.length).toBe(6)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("mention")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("mention")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[5].type).toBe("mention")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello @${user1.name} @${user2.name} @${user3.name}`
+    )
+    expect(messageDraft.value).toBe(`Hello @${user1.name} @${user2.name} @${user3.name}`)
+    await Promise.all([
+      user1.delete({ soft: false }),
+      user2.delete({ soft: false }),
+      user3.delete({ soft: false }),
+    ])
+  })
+
+  test("should mention 2 - 3 users with words between second and third", async () => {
+    const [user1, user2, user3] = await Promise.all([
+      createRandomUser(),
+      createRandomUser(),
+      createRandomUser(),
+    ])
+
+    messageDraft.onChange("Hello @user1 @user2 and @user3")
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addMentionedUser(user2, 1)
+    messageDraft.addMentionedUser(user3, 2)
+    const messagePreview = messageDraft.getMessagePreview()
+    expect(messageDraft.value).toBe(`Hello @${user1.name} @${user2.name} and @${user3.name}`)
+    expect(messagePreview.length).toBe(6)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("mention")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("mention")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[4].content.text).toBe(" and ")
+    expect(messagePreview[5].type).toBe("mention")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello @${user1.name} @${user2.name} and @${user3.name}`
+    )
+    expect(messageDraft.value).toBe(`Hello @${user1.name} @${user2.name} and @${user3.name}`)
+    await Promise.all([
+      user1.delete({ soft: false }),
+      user2.delete({ soft: false }),
+      user3.delete({ soft: false }),
+    ])
+  })
+
+  test("should reference 2 channels", async () => {
+    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
+
+    messageDraft.onChange("Hello #channel1 and #channl2")
+    messageDraft.addReferencedChannel(channel1, 0)
+    messageDraft.addReferencedChannel(channel2, 1)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.length).toBe(4)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("channelReference")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("channelReference")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello #${channel1.name} and #${channel2.name}`
+    )
+    expect(messageDraft.value).toBe(`Hello #${channel1.name} and #${channel2.name}`)
+    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
+  })
+
+  test("should reference 2 channels and 2 mentions", async () => {
+    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
+    const [user1, user2] = await Promise.all([createRandomUser(), createRandomUser()])
+
+    messageDraft.onChange("Hello #channel1 and @brad and #channel2 or @jasmine.")
+    messageDraft.addReferencedChannel(channel1, 0)
+    messageDraft.addReferencedChannel(channel2, 1)
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addMentionedUser(user2, 1)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.length).toBe(9)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("channelReference")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("mention")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[5].type).toBe("channelReference")
+    expect(messagePreview[6].type).toBe("text")
+    expect(messagePreview[7].type).toBe("mention")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello #${channel1.name} and @${user1.name} and #${channel2.name} or @${user2.name}.`
+    )
+    expect(messageDraft.value).toBe(
+      `Hello #${channel1.name} and @${user1.name} and #${channel2.name} or @${user2.name}.`
+    )
+    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
+    await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
+  })
+
+  test("should reference 2 channels and 2 mentions with commas", async () => {
+    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
+    const [user1, user2] = await Promise.all([createRandomUser(), createRandomUser()])
+
+    messageDraft.onChange("Hello #channel1, @brad, #channel2 or @jasmine")
+    messageDraft.addReferencedChannel(channel1, 0)
+    messageDraft.addReferencedChannel(channel2, 1)
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addMentionedUser(user2, 1)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.length).toBe(8)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("channelReference")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("mention")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[5].type).toBe("channelReference")
+    expect(messagePreview[6].type).toBe("text")
+    expect(messagePreview[7].type).toBe("mention")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello #${channel1.name}, @${user1.name}, #${channel2.name} or @${user2.name}`
+    )
+    expect(messageDraft.value).toBe(
+      `Hello #${channel1.name}, @${user1.name}, #${channel2.name} or @${user2.name}`
+    )
+    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
+    await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
+  })
+
+  test("should reference 2 channels and 2 mentions with commas - another variation", async () => {
+    const [channel1, channel2, channel3] = await Promise.all([
+      createRandomChannel(),
+      createRandomChannel(),
+      createRandomChannel(),
+    ])
+    const [user1, user2] = await Promise.all([createRandomUser(), createRandomUser()])
+
+    messageDraft.onChange("Hello #channel1, @brad, #channel2, #some-random-channel, @jasmine")
+    messageDraft.addReferencedChannel(channel1, 0)
+    messageDraft.addReferencedChannel(channel2, 1)
+    messageDraft.addReferencedChannel(channel2, 2)
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addMentionedUser(user2, 1)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.length).toBe(10)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("channelReference")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("mention")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[5].type).toBe("channelReference")
+    expect(messagePreview[6].type).toBe("text")
+    expect(messagePreview[7].type).toBe("channelReference")
+    expect(messagePreview[8].type).toBe("text")
+    expect(messagePreview[9].type).toBe("mention")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello #${channel1.name}, @${user1.name}, #${channel2.name}, #${channel3.name}, @${user2.name}`
+    )
+    expect(messageDraft.value).toBe(
+      `Hello #${channel1.name}, @${user1.name}, #${channel2.name}, #${channel3.name}, @${user2.name}`
+    )
+    await Promise.all([
+      channel1.delete({ soft: false }),
+      channel2.delete({ soft: false }),
+      channel3.delete({ soft: false }),
+    ])
+    await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
+  })
+
+  test("should add 2 text links and 2 plain links", async () => {
+    messageDraft.onChange("Hello https://pubnub.com, https://google.com and ")
+    messageDraft.addLinkedText({
+      text: "pubnub",
+      link: "https://pubnub.com",
+      positionInInput: messageDraft.value.length,
+    })
+    messageDraft.onChange("Hello https://pubnub.com, https://google.com and pubnub, ")
+    messageDraft.addLinkedText({
+      text: "google",
+      link: "https://google.com",
+      positionInInput: messageDraft.value.length,
+    })
+    messageDraft.onChange("Hello https://pubnub.com, https://google.com and pubnub, google.")
+    const messagePreview = messageDraft.getMessagePreview()
+    expect(messagePreview.length).toBe(9)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("plainLink")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("plainLink")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[5].type).toBe("textLink")
+    expect(messagePreview[6].type).toBe("text")
+    expect(messagePreview[7].type).toBe("textLink")
+    expect(messagePreview[8].type).toBe("text")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      "Hello https://pubnub.com, https://google.com and pubnub, google."
+    )
+    expect(messageDraft.value).toBe(
+      "Hello https://pubnub.com, https://google.com and pubnub, google."
+    )
+  })
+
+  test("should mix every type of message part", async () => {
+    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
+    const [user1, user2, user4, user5] = await Promise.all([
+      createRandomUser(),
+      createRandomUser(),
+      createRandomUser(),
+      createRandomUser(),
+    ])
+    messageDraft.onChange("Hello ")
+    messageDraft.addLinkedText({
+      text: "pubnub",
+      link: "https://pubnub.com",
+      positionInInput: messageDraft.value.length,
+    })
+    messageDraft.onChange("Hello pubnub at https://pubnub.com! Hello to ")
+    messageDraft.addLinkedText({
+      text: "google",
+      link: "https://google.com",
+      positionInInput: messageDraft.value.length,
+    })
+    messageDraft.onChange(
+      "Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing #channel1, #channel2, #blankchannel, @user1, @user2, and mentioning @blankuser3 @user4 @user5"
+    )
+    messageDraft.addReferencedChannel(channel1, 0)
+    messageDraft.addReferencedChannel(channel2, 1)
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addMentionedUser(user2, 1)
+    messageDraft.addMentionedUser(user4, 3)
+    messageDraft.addMentionedUser(user5, 4)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.length).toBe(20)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("textLink")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("plainLink")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[5].type).toBe("textLink")
+    expect(messagePreview[6].type).toBe("text")
+    expect(messagePreview[7].type).toBe("plainLink")
+    expect(messagePreview[8].type).toBe("text")
+    expect(messagePreview[9].type).toBe("channelReference")
+    expect(messagePreview[10].type).toBe("text")
+    expect(messagePreview[11].type).toBe("channelReference")
+    expect(messagePreview[12].type).toBe("text")
+    expect(messagePreview[13].type).toBe("mention")
+    expect(messagePreview[14].type).toBe("text")
+    expect(messagePreview[15].type).toBe("mention")
+    expect(messagePreview[16].type).toBe("text")
+    expect(messagePreview[17].type).toBe("mention")
+    expect(messagePreview[18].type).toBe("text")
+    expect(messagePreview[19].type).toBe("mention")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing #${channel1.name}, #${channel2.name}, #blankchannel, @${user1.name}, @${user2.name}, and mentioning @blankuser3 @${user4.name} @${user5.name}`
+    )
+    expect(messageDraft.value).toBe(
+      `Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing #${channel1.name}, #${channel2.name}, #blankchannel, @${user1.name}, @${user2.name}, and mentioning @blankuser3 @${user4.name} @${user5.name}`
+    )
+    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
+    await Promise.all([
+      user1.delete({ soft: false }),
+      user2.delete({ soft: false }),
+      user4.delete({ soft: false }),
+    ])
+  })
+
+  test("should mix every type of message part - variant 2", async () => {
+    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
+    const [user1, user2, user4, user5] = await Promise.all([
+      createRandomUser(),
+      createRandomUser(),
+      createRandomUser(),
+      createRandomUser(),
+    ])
+    messageDraft.onChange("Hello @user1 #channel1 ")
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addReferencedChannel(channel1, 0)
+    messageDraft.onChange(`${messageDraft.value} `)
+    messageDraft.addLinkedText({
+      text: "pubnub",
+      link: "https://pubnub.com",
+      positionInInput: messageDraft.value.length,
+    })
+    messageDraft.onChange(`${messageDraft.value} at https://pubnub.com. `)
+    messageDraft.addLinkedText({
+      text: "google",
+      link: "https://google.com",
+      positionInInput: messageDraft.value.length,
+    })
+    messageDraft.onChange(
+      `${messageDraft.value} at https://google.com, @user2 @blankuser3 #channel2, random text @user4, @user5.`
+    )
+    messageDraft.addReferencedChannel(channel2, 1)
+    messageDraft.addMentionedUser(user2, 1)
+    messageDraft.addMentionedUser(user4, 3)
+    messageDraft.addMentionedUser(user5, 4)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.length).toBe(21)
+    expect(messagePreview[0].type).toBe("text")
+    expect(messagePreview[1].type).toBe("mention")
+    expect(messagePreview[2].type).toBe("text")
+    expect(messagePreview[3].type).toBe("channelReference")
+    expect(messagePreview[4].type).toBe("text")
+    expect(messagePreview[5].type).toBe("textLink")
+    expect(messagePreview[6].type).toBe("text")
+    expect(messagePreview[7].type).toBe("plainLink")
+    expect(messagePreview[8].type).toBe("text")
+    expect(messagePreview[9].type).toBe("textLink")
+    expect(messagePreview[10].type).toBe("text")
+    expect(messagePreview[11].type).toBe("plainLink")
+    expect(messagePreview[12].type).toBe("text")
+    expect(messagePreview[13].type).toBe("mention")
+    expect(messagePreview[14].type).toBe("text")
+    expect(messagePreview[15].type).toBe("channelReference")
+    expect(messagePreview[16].type).toBe("text")
+    expect(messagePreview[17].type).toBe("mention")
+    expect(messagePreview[18].type).toBe("text")
+    expect(messagePreview[19].type).toBe("mention")
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      `Hello @Test User #Test Channel pubnub at https://pubnub.com. google at https://google.com, @Test User @blankuser3 #Test Channel, random text @Test User, @Test User.`
+    )
+    expect(messageDraft.value).toBe(
+      `Hello @Test User #Test Channel pubnub at https://pubnub.com. google at https://google.com, @Test User @blankuser3 #Test Channel, random text @Test User, @Test User.`
+    )
+    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
+    await Promise.all([
+      user1.delete({ soft: false }),
+      user2.delete({ soft: false }),
+      user4.delete({ soft: false }),
+    ])
+  })
+
+  test("should reference 3 channels and 3 mentions with no order", async () => {
+    const [channel1, channel2, channel3] = await Promise.all([
+      createRandomChannel(),
+      createRandomChannel(),
+      createRandomChannel(),
+    ])
+    const [user1, user2, user3] = await Promise.all([
+      createRandomUser(),
+      createRandomUser(),
+      createRandomUser(),
+    ])
+
+    messageDraft.onChange(
+      `Hello @real #real #fake @fake @real #fake #fake #real @real #fake #real @@@ @@@@ @ #fake #fake`
+    )
+    messageDraft.addReferencedChannel(channel1, 0)
+    messageDraft.addReferencedChannel(channel2, 4)
+    messageDraft.addReferencedChannel(channel3, 6)
+    messageDraft.addMentionedUser(user1, 0)
+    messageDraft.addMentionedUser(user2, 2)
+    messageDraft.addMentionedUser(user3, 3)
+    const messagePreview = messageDraft.getMessagePreview()
+
+    expect(messagePreview.map(renderMessagePart).join("")).toBe(
+      "Hello @Test User #Test Channel #fake @fake @Test User #fake #fake #Test Channel @Test User #fake #Test Channel @@@ @@@@ @ #fake #fake"
+    )
+
+    await Promise.all([
+      channel1.delete({ soft: false }),
+      channel2.delete({ soft: false }),
+      channel3.delete({ soft: false }),
+    ])
+    await Promise.all([
+      user1.delete({ soft: false }),
+      user2.delete({ soft: false }),
+      user3.delete({ soft: false }),
+    ])
+  })
+})

--- a/js-chat/tests/message-draft-v2.test.ts
+++ b/js-chat/tests/message-draft-v2.test.ts
@@ -5,6 +5,7 @@ import {
   createRandomUser,
   renderMessagePart,
   sleep,
+  makeid
 } from "./utils"
 import { jest } from "@jest/globals"
 
@@ -37,12 +38,12 @@ describe("MessageDraft", function () {
     expect(messagePreview[3].type).toBe("mention")
     expect(messageDraft.value).toBe(`Hello @user1 and @user2`)
     expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      `Hello @user1 and @user2`
+      `Hello @@user1 and @@user2`
     )
     await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
   })
 
-  test.only("should mention 2 - 3 users next to each other", async () => {
+  test("should mention 2 - 3 users next to each other", async () => {
     const [user1, user2, user3] = await Promise.all([
       createRandomUser(),
       createRandomUser(),
@@ -85,249 +86,74 @@ describe("MessageDraft", function () {
     ])
   })
 
-  test("should mention 2 - 3 users with words between second and third", async () => {
-    const [user1, user2, user3] = await Promise.all([
-      createRandomUser(),
-      createRandomUser(),
-      createRandomUser(),
+  test("should mix every type of message part", async () => {
+    const [channel1, channel2] = await Promise.all([createRandomChannel(makeid()), createRandomChannel(makeid())])
+    const [user1, user2, user4, user5] = await Promise.all([
+      createRandomUser(makeid()),
+      createRandomUser(makeid()),
+      createRandomUser(makeid()),
+      createRandomUser(makeid()),
     ])
+    messageDraft.update("Hello ")
+    messageDraft.addLinkedText({
+      text: "pubnub",
+      link: "https://pubnub.com",
+      positionInInput: messageDraft.value.length,
+    })
+    messageDraft.update("Hello pubnub at https://pubnub.com! Hello to ")
+    messageDraft.addLinkedText({
+      text: "google",
+      link: "https://google.com",
+      positionInInput: messageDraft.value.length,
+    })
 
-    messageDraft.onChange("Hello @user1 @user2 and @user3")
-    messageDraft.addMentionedUser(user1, 0)
-    messageDraft.addMentionedUser(user2, 1)
-    messageDraft.addMentionedUser(user3, 2)
-    const messagePreview = messageDraft.getMessagePreview()
-    expect(messageDraft.value).toBe(`Hello @${user1.name} @${user2.name} and @${user3.name}`)
-    expect(messagePreview.length).toBe(6)
-    expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("mention")
-    expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("mention")
-    expect(messagePreview[4].type).toBe("text")
-    expect(messagePreview[4].content.text).toBe(" and ")
-    expect(messagePreview[5].type).toBe("mention")
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      `Hello @${user1.name} @${user2.name} and @${user3.name}`
+   let elements: MixedTextTypedElement[][] = []
+    let resolve, reject;
+    const promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    messageDraft.addChangeListener(async function(state) {
+      elements.push(state.messageElements)
+      let mentions = await state.suggestedMentions
+      if (mentions.length == 0) {
+          resolve()
+          return
+      }
+      messageDraft.insertSuggestedMention(mentions[0], mentions[0].replaceWith)
+    })
+
+
+    messageDraft.update(
+      `Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing #${channel1.name.substring(0,8)}, #${channel2.name.substring(0,8)}, #blankchannel, @${user1.name.substring(0,8)}, @${user2.name.substring(0,8)}, and mentioning @blankuser3 @${user4.name.substring(0,8)} @${user5.name.substring(0,8)}`
     )
-    expect(messageDraft.value).toBe(`Hello @${user1.name} @${user2.name} and @${user3.name}`)
-    await Promise.all([
-      user1.delete({ soft: false }),
-      user2.delete({ soft: false }),
-      user3.delete({ soft: false }),
-    ])
-  })
+    await promise
 
-  test("should reference 2 channels", async () => {
-    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
-
-    messageDraft.onChange("Hello #channel1 and #channl2")
-    messageDraft.addReferencedChannel(channel1, 0)
-    messageDraft.addReferencedChannel(channel2, 1)
-    const messagePreview = messageDraft.getMessagePreview()
-
-    expect(messagePreview.length).toBe(4)
-    expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("channelReference")
-    expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("channelReference")
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      `Hello #${channel1.name} and #${channel2.name}`
-    )
-    expect(messageDraft.value).toBe(`Hello #${channel1.name} and #${channel2.name}`)
-    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
-  })
-
-  test("should reference 2 channels and 2 mentions", async () => {
-    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
-    const [user1, user2] = await Promise.all([createRandomUser(), createRandomUser()])
-
-    messageDraft.update("Hello #channel1 and @brad and #channel2 or @jasmine.")
-    messageDraft.addReferencedChannel(channel1, 0)
-    messageDraft.addReferencedChannel(channel2, 1)
-    messageDraft.addMentionedUser(user1, 0)
-    messageDraft.addMentionedUser(user2, 1)
     const messagePreview = messageDraft.getMessagePreview()
 
-    expect(messagePreview.length).toBe(9)
+    expect(messagePreview.length).toBe(16)
     expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("channelReference")
+    expect(messagePreview[1].type).toBe("textLink")
     expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("mention")
-    expect(messagePreview[4].type).toBe("text")
-    expect(messagePreview[5].type).toBe("channelReference")
-    expect(messagePreview[6].type).toBe("text")
-    expect(messagePreview[7].type).toBe("mention")
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      `Hello #${channel1.name} and @${user1.name} and #${channel2.name} or @${user2.name}.`
-    )
-    expect(messageDraft.value).toBe(
-      `Hello #${channel1.name} and @${user1.name} and #${channel2.name} or @${user2.name}.`
-    )
-    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
-    await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
-  })
-
-  test("should reference 2 channels and 2 mentions with commas", async () => {
-    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
-    const [user1, user2] = await Promise.all([createRandomUser(), createRandomUser()])
-
-    messageDraft.onChange("Hello #channel1, @brad, #channel2 or @jasmine")
-    messageDraft.addReferencedChannel(channel1, 0)
-    messageDraft.addReferencedChannel(channel2, 1)
-    messageDraft.addMentionedUser(user1, 0)
-    messageDraft.addMentionedUser(user2, 1)
-    const messagePreview = messageDraft.getMessagePreview()
-
-    expect(messagePreview.length).toBe(8)
-    expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("channelReference")
-    expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("mention")
-    expect(messagePreview[4].type).toBe("text")
-    expect(messagePreview[5].type).toBe("channelReference")
-    expect(messagePreview[6].type).toBe("text")
-    expect(messagePreview[7].type).toBe("mention")
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      `Hello #${channel1.name}, @${user1.name}, #${channel2.name} or @${user2.name}`
-    )
-    expect(messageDraft.value).toBe(
-      `Hello #${channel1.name}, @${user1.name}, #${channel2.name} or @${user2.name}`
-    )
-    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
-    await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
-  })
-
-  test("should reference 2 channels and 2 mentions with commas - another variation", async () => {
-    const [channel1, channel2, channel3] = await Promise.all([
-      createRandomChannel(),
-      createRandomChannel(),
-      createRandomChannel(),
-    ])
-    const [user1, user2] = await Promise.all([createRandomUser(), createRandomUser()])
-
-    messageDraft.onChange("Hello #channel1, @brad, #channel2, #some-random-channel, @jasmine")
-    messageDraft.addReferencedChannel(channel1, 0)
-    messageDraft.addReferencedChannel(channel2, 1)
-    messageDraft.addReferencedChannel(channel2, 2)
-    messageDraft.addMentionedUser(user1, 0)
-    messageDraft.addMentionedUser(user2, 1)
-    const messagePreview = messageDraft.getMessagePreview()
-
-    expect(messagePreview.length).toBe(10)
-    expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("channelReference")
-    expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("mention")
+    expect(messagePreview[3].type).toBe("textLink")
     expect(messagePreview[4].type).toBe("text")
     expect(messagePreview[5].type).toBe("channelReference")
     expect(messagePreview[6].type).toBe("text")
     expect(messagePreview[7].type).toBe("channelReference")
     expect(messagePreview[8].type).toBe("text")
     expect(messagePreview[9].type).toBe("mention")
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      `Hello #${channel1.name}, @${user1.name}, #${channel2.name}, #${channel3.name}, @${user2.name}`
-    )
-    expect(messageDraft.value).toBe(
-      `Hello #${channel1.name}, @${user1.name}, #${channel2.name}, #${channel3.name}, @${user2.name}`
-    )
-    await Promise.all([
-      channel1.delete({ soft: false }),
-      channel2.delete({ soft: false }),
-      channel3.delete({ soft: false }),
-    ])
-    await Promise.all([user1.delete({ soft: false }), user2.delete({ soft: false })])
-  })
-
-  test("should add 2 text links and 2 plain links", async () => {
-    messageDraft.onChange("Hello https://pubnub.com, https://google.com and ")
-    messageDraft.addLinkedText({
-      text: "pubnub",
-      link: "https://pubnub.com",
-      positionInInput: messageDraft.value.length,
-    })
-    messageDraft.onChange("Hello https://pubnub.com, https://google.com and pubnub, ")
-    messageDraft.addLinkedText({
-      text: "google",
-      link: "https://google.com",
-      positionInInput: messageDraft.value.length,
-    })
-    messageDraft.onChange("Hello https://pubnub.com, https://google.com and pubnub, google.")
-    const messagePreview = messageDraft.getMessagePreview()
-    expect(messagePreview.length).toBe(9)
-    expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("plainLink")
-    expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("plainLink")
-    expect(messagePreview[4].type).toBe("text")
-    expect(messagePreview[5].type).toBe("textLink")
-    expect(messagePreview[6].type).toBe("text")
-    expect(messagePreview[7].type).toBe("textLink")
-    expect(messagePreview[8].type).toBe("text")
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      "Hello https://pubnub.com, https://google.com and pubnub, google."
-    )
-    expect(messageDraft.value).toBe(
-      "Hello https://pubnub.com, https://google.com and pubnub, google."
-    )
-  })
-
-  test("should mix every type of message part", async () => {
-    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
-    const [user1, user2, user4, user5] = await Promise.all([
-      createRandomUser(),
-      createRandomUser(),
-      createRandomUser(),
-      createRandomUser(),
-    ])
-    messageDraft.onChange("Hello ")
-    messageDraft.addLinkedText({
-      text: "pubnub",
-      link: "https://pubnub.com",
-      positionInInput: messageDraft.value.length,
-    })
-    messageDraft.onChange("Hello pubnub at https://pubnub.com! Hello to ")
-    messageDraft.addLinkedText({
-      text: "google",
-      link: "https://google.com",
-      positionInInput: messageDraft.value.length,
-    })
-    messageDraft.onChange(
-      "Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing #channel1, #channel2, #blankchannel, @user1, @user2, and mentioning @blankuser3 @user4 @user5"
-    )
-    messageDraft.addReferencedChannel(channel1, 0)
-    messageDraft.addReferencedChannel(channel2, 1)
-    messageDraft.addMentionedUser(user1, 0)
-    messageDraft.addMentionedUser(user2, 1)
-    messageDraft.addMentionedUser(user4, 3)
-    messageDraft.addMentionedUser(user5, 4)
-    const messagePreview = messageDraft.getMessagePreview()
-
-    expect(messagePreview.length).toBe(20)
-    expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("textLink")
-    expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("plainLink")
-    expect(messagePreview[4].type).toBe("text")
-    expect(messagePreview[5].type).toBe("textLink")
-    expect(messagePreview[6].type).toBe("text")
-    expect(messagePreview[7].type).toBe("plainLink")
-    expect(messagePreview[8].type).toBe("text")
-    expect(messagePreview[9].type).toBe("channelReference")
     expect(messagePreview[10].type).toBe("text")
-    expect(messagePreview[11].type).toBe("channelReference")
+    expect(messagePreview[11].type).toBe("mention")
     expect(messagePreview[12].type).toBe("text")
     expect(messagePreview[13].type).toBe("mention")
     expect(messagePreview[14].type).toBe("text")
     expect(messagePreview[15].type).toBe("mention")
-    expect(messagePreview[16].type).toBe("text")
-    expect(messagePreview[17].type).toBe("mention")
-    expect(messagePreview[18].type).toBe("text")
-    expect(messagePreview[19].type).toBe("mention")
     expect(messagePreview.map(renderMessagePart).join("")).toBe(
       `Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing #${channel1.name}, #${channel2.name}, #blankchannel, @${user1.name}, @${user2.name}, and mentioning @blankuser3 @${user4.name} @${user5.name}`
     )
     expect(messageDraft.value).toBe(
-      `Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing #${channel1.name}, #${channel2.name}, #blankchannel, @${user1.name}, @${user2.name}, and mentioning @blankuser3 @${user4.name} @${user5.name}`
+      `Hello pubnub at https://pubnub.com! Hello to google at https://google.com. Referencing ${channel1.name}, ${channel2.name}, #blankchannel, ${user1.name}, ${user2.name}, and mentioning @blankuser3 ${user4.name} ${user5.name}`
     )
     await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
     await Promise.all([
@@ -337,109 +163,4 @@ describe("MessageDraft", function () {
     ])
   })
 
-  test("should mix every type of message part - variant 2", async () => {
-    const [channel1, channel2] = await Promise.all([createRandomChannel(), createRandomChannel()])
-    const [user1, user2, user4, user5] = await Promise.all([
-      createRandomUser(),
-      createRandomUser(),
-      createRandomUser(),
-      createRandomUser(),
-    ])
-    messageDraft.onChange("Hello @user1 #channel1 ")
-    messageDraft.addMentionedUser(user1, 0)
-    messageDraft.addReferencedChannel(channel1, 0)
-    messageDraft.onChange(`${messageDraft.value} `)
-    messageDraft.addLinkedText({
-      text: "pubnub",
-      link: "https://pubnub.com",
-      positionInInput: messageDraft.value.length,
-    })
-    messageDraft.onChange(`${messageDraft.value} at https://pubnub.com. `)
-    messageDraft.addLinkedText({
-      text: "google",
-      link: "https://google.com",
-      positionInInput: messageDraft.value.length,
-    })
-    messageDraft.onChange(
-      `${messageDraft.value} at https://google.com, @user2 @blankuser3 #channel2, random text @user4, @user5.`
-    )
-    messageDraft.addReferencedChannel(channel2, 1)
-    messageDraft.addMentionedUser(user2, 1)
-    messageDraft.addMentionedUser(user4, 3)
-    messageDraft.addMentionedUser(user5, 4)
-    const messagePreview = messageDraft.getMessagePreview()
-
-    expect(messagePreview.length).toBe(21)
-    expect(messagePreview[0].type).toBe("text")
-    expect(messagePreview[1].type).toBe("mention")
-    expect(messagePreview[2].type).toBe("text")
-    expect(messagePreview[3].type).toBe("channelReference")
-    expect(messagePreview[4].type).toBe("text")
-    expect(messagePreview[5].type).toBe("textLink")
-    expect(messagePreview[6].type).toBe("text")
-    expect(messagePreview[7].type).toBe("plainLink")
-    expect(messagePreview[8].type).toBe("text")
-    expect(messagePreview[9].type).toBe("textLink")
-    expect(messagePreview[10].type).toBe("text")
-    expect(messagePreview[11].type).toBe("plainLink")
-    expect(messagePreview[12].type).toBe("text")
-    expect(messagePreview[13].type).toBe("mention")
-    expect(messagePreview[14].type).toBe("text")
-    expect(messagePreview[15].type).toBe("channelReference")
-    expect(messagePreview[16].type).toBe("text")
-    expect(messagePreview[17].type).toBe("mention")
-    expect(messagePreview[18].type).toBe("text")
-    expect(messagePreview[19].type).toBe("mention")
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      `Hello @Test User #Test Channel pubnub at https://pubnub.com. google at https://google.com, @Test User @blankuser3 #Test Channel, random text @Test User, @Test User.`
-    )
-    expect(messageDraft.value).toBe(
-      `Hello @Test User #Test Channel pubnub at https://pubnub.com. google at https://google.com, @Test User @blankuser3 #Test Channel, random text @Test User, @Test User.`
-    )
-    await Promise.all([channel1.delete({ soft: false }), channel2.delete({ soft: false })])
-    await Promise.all([
-      user1.delete({ soft: false }),
-      user2.delete({ soft: false }),
-      user4.delete({ soft: false }),
-    ])
-  })
-
-  test("should reference 3 channels and 3 mentions with no order", async () => {
-    const [channel1, channel2, channel3] = await Promise.all([
-      createRandomChannel(),
-      createRandomChannel(),
-      createRandomChannel(),
-    ])
-    const [user1, user2, user3] = await Promise.all([
-      createRandomUser(),
-      createRandomUser(),
-      createRandomUser(),
-    ])
-
-    messageDraft.onChange(
-      `Hello @real #real #fake @fake @real #fake #fake #real @real #fake #real @@@ @@@@ @ #fake #fake`
-    )
-    messageDraft.addReferencedChannel(channel1, 0)
-    messageDraft.addReferencedChannel(channel2, 4)
-    messageDraft.addReferencedChannel(channel3, 6)
-    messageDraft.addMentionedUser(user1, 0)
-    messageDraft.addMentionedUser(user2, 2)
-    messageDraft.addMentionedUser(user3, 3)
-    const messagePreview = messageDraft.getMessagePreview()
-
-    expect(messagePreview.map(renderMessagePart).join("")).toBe(
-      "Hello @Test User #Test Channel #fake @fake @Test User #fake #fake #Test Channel @Test User #fake #Test Channel @@@ @@@@ @ #fake #fake"
-    )
-
-    await Promise.all([
-      channel1.delete({ soft: false }),
-      channel2.delete({ soft: false }),
-      channel3.delete({ soft: false }),
-    ])
-    await Promise.all([
-      user1.delete({ soft: false }),
-      user2.delete({ soft: false }),
-      user3.delete({ soft: false }),
-    ])
-  })
 })

--- a/js-chat/tests/message.test.ts
+++ b/js-chat/tests/message.test.ts
@@ -1037,11 +1037,11 @@ describe("Send message test", () => {
 
     const firstThreadMessage = (await thread.getHistory()).messages[0]
 
-    const messageDraft = thread.createMessageDraft()
+    const messageDraft = thread.createMessageDraftV2()
 
     messageDraft.addQuote(firstThreadMessage)
 
-    await messageDraft.onChange("This is a forwarded message.")
+    await messageDraft.update("This is a forwarded message.")
     await messageDraft.send()
 
     await sleep(500)

--- a/js-chat/tests/utils.ts
+++ b/js-chat/tests/utils.ts
@@ -64,16 +64,18 @@ export async function createChatInstance(
   return chat
 }
 
-export function createRandomChannel() {
-  return chat.createChannel(`channel_${makeid()}`, {
-    name: "Test Channel",
+export function createRandomChannel(prefix?: string) {
+  if (!prefix) prefix = ""
+  return chat.createChannel(`${prefix}channel_${makeid()}`, {
+    name: `${prefix}Test Channel`,
     description: "This is a test channel",
   })
 }
 
-export function createRandomUser() {
-  return chat.createUser(`user_${makeid()}`, {
-    name: "Test User",
+export function createRandomUser(prefix?: string) {
+  if (!prefix) prefix = ""
+  return chat.createUser(`${prefix}user_${makeid()}`, {
+    name: `${prefix}Test User`,
   })
 }
 

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/UuidTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/UuidTest.kt
@@ -1,0 +1,13 @@
+package com.pubnub.kmp
+
+import com.pubnub.chat.internal.generateRandomUuid
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class UuidTest {
+    @Test
+    fun generateUuid() {
+        val uuid = generateRandomUuid()
+        assertTrue { uuid.matches(Regex("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")) }
+    }
+}

--- a/pubnub-chat-impl/src/jsMain/kotlin/ChannelJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/ChannelJs.kt
@@ -200,6 +200,7 @@ open class ChannelJs internal constructor(internal val channel: Channel, interna
 
     fun createMessageDraftV2(config: MessageDraftConfig?): MessageDraftV2Js {
         return MessageDraftV2Js(
+            this.chatJs,
             MessageDraftImpl(
                 this.channel,
                 config?.userSuggestionSource?.let {
@@ -209,7 +210,12 @@ open class ChannelJs internal constructor(internal val channel: Channel, interna
                 config?.userLimit ?: 10,
                 config?.channelLimit ?: 10
             ),
-            config
+            createJsObject<MessageDraftConfig> {
+                this.userSuggestionSource = config?.userSuggestionSource ?: "channel"
+                this.isTypingIndicatorTriggered = config?.isTypingIndicatorTriggered ?: (channel.type != ChannelType.PUBLIC)
+                this.userLimit = config?.userLimit ?: 10
+                this.channelLimit = config?.channelLimit ?: 10
+            }
         )
     }
 

--- a/pubnub-chat-impl/src/jsMain/kotlin/MessageDraftV2Js.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/MessageDraftV2Js.kt
@@ -177,10 +177,10 @@ fun List<MessageElement>.toJs() = map { element ->
     when (element) {
         is MessageElement.Link -> when (val target = element.target) {
             is MentionTarget.Channel -> MixedTextTypedElement.ChannelReference(
-                ChannelReferenceContent(target.channelId, element.text.substring(1))
+                ChannelReferenceContent(target.channelId, element.text)
             )
             is MentionTarget.Url -> MixedTextTypedElement.TextLink(TextLinkContent(target.url, element.text))
-            is MentionTarget.User -> MixedTextTypedElement.Mention(MentionContent(target.userId, element.text.substring(1)))
+            is MentionTarget.User -> MixedTextTypedElement.Mention(MentionContent(target.userId, element.text))
         }
         is MessageElement.PlainText -> MixedTextTypedElement.Text(TextContent(element.text))
     }

--- a/pubnub-chat-impl/src/jsMain/kotlin/com/pubnub/chat/internal/ChatImpl.js.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/com/pubnub/chat/internal/ChatImpl.js.kt
@@ -1,16 +1,26 @@
 package com.pubnub.chat.internal
 
+import kotlin.experimental.and
+import kotlin.experimental.or
+import kotlin.math.floor
+import kotlin.random.Random
 import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 external val globalThis: dynamic
 
 @OptIn(ExperimentalUuidApi::class)
 actual fun generateRandomUuid(): String {
-    val process = js("process")
-    if (process !== undefined && process.versions && process.versions.node && globalThis.crypto === undefined) {
-        // Node.js environment detected
-        globalThis.crypto = js("require('crypto')")
+    val uuid = ByteArray(32)
+    for (i in 0 until 32) {
+        uuid[i] = floor(Random.nextDouble() * 16).toInt().toByte()
     }
-    return Uuid.random().toString()
+    uuid[12] = 4; // set bits 12-15 of time-high-and-version to 0100
+    uuid[16] = uuid[19] and (1 shl 2).inv().toByte() // set bit 6 of clock-seq-and-reserved to zero
+    uuid[16] = uuid[19] or (1 shl 3).toByte(); // set bit 7 of clock-seq-and-reserved to one
+    val uuidString = uuid.joinToString("") { it.toString(16) }
+    return uuidString.substring(0, 8) +
+        "-" + uuidString.substring(8, 12) +
+        "-" + uuidString.substring(12, 16) +
+        "-" + uuidString.substring(16, 20) +
+        "-" + uuidString.substring(20)
 }

--- a/src/jsMain/resources/index.d.ts
+++ b/src/jsMain/resources/index.d.ts
@@ -422,9 +422,9 @@ type AddLinkedTextParams = {
     positionInInput: number;
 };
 
-declare class MessageDraftV2 {
-    get channel: Channel;
-    get value: string;
+export declare class MessageDraftV2 {
+    get channel(): Channel;
+    get value(): string;
     quotedMessage: Message | undefined;
     readonly config: MessageDraftConfig;
     files?: FileList | File[] | SendFileParameters["file"][];
@@ -438,20 +438,19 @@ declare class MessageDraftV2 {
     removeChangeListener(listener: (p0: MessageDraftState) => void): void;
     insertText(offset: number, text: string): void;
     removeText(offset: number, length: number): void;
-    removeText(offset: number, length: number): void;
     insertSuggestedMention(mention: SuggestedMention, text: string): void;
     addMention(offset: number, length: number, mentionType: TextTypes, mentionTarget: string): void;
     removeMention(offset: number): void;
     update(text: string): void;
 }
 
-declare class MessageDraftState {
+export declare class MessageDraftState {
     private constructor();
     get messageElements(): Array<MixedTextTypedElement>;
     get suggestedMentions(): Promise<Array<SuggestedMention>>;
 }
 
-declare class SuggestedMention {
+export declare class SuggestedMention {
     offset: number;
     replaceFrom: string;
     replaceWith: string;

--- a/src/jsMain/resources/index.d.ts
+++ b/src/jsMain/resources/index.d.ts
@@ -434,8 +434,8 @@ declare class MessageDraftV2 {
     removeLinkedText(positionInInput: number): void;
     getMessagePreview(): MixedTextTypedElement[];
     send(params?: MessageDraftOptions): Promise<PubNub.PublishResponse>;
-    addChangeListener(listener:(messageElements: MixedTextTypedElement[], suggestedMentions:Promise<SuggestedMention[]>) => unknown): void;
-    removeChangeListener(listener:(messageElements: MixedTextTypedElement[], suggestedMentions:Promise<SuggestedMention[]>) => unknown): void;
+    addChangeListener(listener: (p0: MessageDraftState) => void): void;
+    removeChangeListener(listener: (p0: MessageDraftState) => void): void;
     insertText(offset: number, text: string): void;
     removeText(offset: number, length: number): void;
     removeText(offset: number, length: number): void;
@@ -443,6 +443,12 @@ declare class MessageDraftV2 {
     addMention(offset: number, length: number, mentionType: TextTypes, mentionTarget: string): void;
     removeMention(offset: number): void;
     update(text: string): void;
+}
+
+declare class MessageDraftState {
+    private constructor();
+    get messageElements(): Array<MixedTextTypedElement>;
+    get suggestedMentions(): Promise<Array<SuggestedMention>>;
 }
 
 declare class SuggestedMention {

--- a/src/jsMain/resources/index.d.ts
+++ b/src/jsMain/resources/index.d.ts
@@ -421,6 +421,38 @@ type AddLinkedTextParams = {
     link: string;
     positionInInput: number;
 };
+
+declare class MessageDraftV2 {
+    get channel: Channel;
+    get value: string;
+    quotedMessage: Message | undefined;
+    readonly config: MessageDraftConfig;
+    files?: FileList | File[] | SendFileParameters["file"][];
+    addQuote(message: Message): void;
+    removeQuote(): void;
+    addLinkedText(params: AddLinkedTextParams): void;
+    removeLinkedText(positionInInput: number): void;
+    getMessagePreview(): MixedTextTypedElement[];
+    send(params?: MessageDraftOptions): Promise<PubNub.PublishResponse>;
+    addChangeListener(listener:(messageElements: MixedTextTypedElement[], suggestedMentions:Promise<SuggestedMention[]>) => unknown): void;
+    removeChangeListener(listener:(messageElements: MixedTextTypedElement[], suggestedMentions:Promise<SuggestedMention[]>) => unknown): void;
+    insertText(offset: number, text: string): void;
+    removeText(offset: number, length: number): void;
+    removeText(offset: number, length: number): void;
+    insertSuggestedMention(mention: SuggestedMention, text: string): void;
+    addMention(offset: number, length: number, mentionType: TextTypes, mentionTarget: string): void;
+    removeMention(offset: number): void;
+    update(text: string): void;
+}
+
+declare class SuggestedMention {
+    offset: number;
+    replaceFrom: string;
+    replaceWith: string;
+    type: TextTypes;
+    target: string;
+}
+
 declare class MessageDraft {
     private chat;
     value: string;
@@ -527,6 +559,7 @@ declare class Channel {
         limit: number;
     }): Promise<Membership[]>;
     createMessageDraft(config?: Partial<MessageDraftConfig>): MessageDraft;
+    createMessageDraftV2(config?: Partial<MessageDraftConfig>): MessageDraftV2;
     registerForPush(): Promise<void>;
     unregisterFromPush(): Promise<void>;
     streamReadReceipts(callback: (receipts: {


### PR DESCRIPTION
fix: Wrong user suggestion source for message draft created on ThreadChannel
fix: Wrong type of last user activity time stored on server (precision)
feat: Lock moderated messages from editing 
refactor: Moderation events are now sent to a channel prefixed with `PUBNUB_INTERNAL_MODERATION.`
