### PR TITLE
[CI] Fix xcframework bundling scripts

### DIFF
--- a/.github/workflows/release/kotlin-maven-build.sh
+++ b/.github/workflows/release/kotlin-maven-build.sh
@@ -3,8 +3,10 @@ echo "Build Kotlin and Swift Chat SDK module artifacts"
 ./gradlew -PENABLE_TARGET_IOS_ALL=true :podPublishReleaseXCFramework assemble
 find build/cocoapods/publish/release/PubNubChat.xcframework -exec touch -t 00000000 {} +
 rm -f build/cocoapods/publish/release/PubNubChat.xcframework.zip
-zip -X -vr build/cocoapods/publish/release/PubNubChat.xcframework.zip build/cocoapods/publish/release/PubNubChat.xcframework
-touch -t 00000000 build/cocoapods/publish/release/PubNubChat.xcframework.zip
+pushd build/cocoapods/publish/release
+zip -X -vr PubNubChat.xcframework.zip PubNubChat.xcframework
+touch -t 00000000 PubNubChat.xcframework.zip
+popd
 CHECKSUM=$(swift package compute-checksum build/cocoapods/publish/release/PubNubChat.xcframework.zip)
 echo $CHECKSUM
 mkdir build/gh_artifacts

--- a/.github/workflows/release/kotlin-pre-publish.sh
+++ b/.github/workflows/release/kotlin-pre-publish.sh
@@ -3,8 +3,10 @@ echo "Update Swift Chat SDK checksum in Package.swift"
 ./gradlew -PENABLE_TARGET_IOS_ALL=true :podPublishReleaseXCFramework
 find build/cocoapods/publish/release/PubNubChat.xcframework -exec touch -t 00000000 {} +
 rm -f build/cocoapods/publish/release/PubNubChat.xcframework.zip
-zip -X -vr build/cocoapods/publish/release/PubNubChat.xcframework.zip build/cocoapods/publish/release/PubNubChat.xcframework
-touch -t 00000000 build/cocoapods/publish/release/PubNubChat.xcframework.zip
+pushd build/cocoapods/publish/release
+zip -X -vr PubNubChat.xcframework.zip PubNubChat.xcframework
+touch -t 00000000 PubNubChat.xcframework.zip
+popd
 CHECKSUM=$(swift package compute-checksum build/cocoapods/publish/release/PubNubChat.xcframework.zip)
 echo $CHECKSUM
 sed -i.bak "s/checksum: \"[a-z0-9]*\"/checksum: \"$CHECKSUM\"/g" Package.swift


### PR DESCRIPTION
xcframework.zip must not contain a directory structure other than the xcframework itself.