### PR TITLE
Fix setRestrictions with referential integrity enabled

### DIFF
--- a/.github/workflows/release/versions.json
+++ b/.github/workflows/release/versions.json
@@ -6,6 +6,13 @@
       "clearedSuffix": false
     }
   ],
+  "../gradle.properties": [
+    {
+      "pattern": "^VERSION_NAME=(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)$",
+      "clearedPrefix": true,
+      "clearedSuffix": false
+    }
+  ],
   "README.md": [
     {
       "pattern": "^\\s{2,}<version>(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)<\\/version>$",

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: kmp-chat
-version: 0.9.3
+version: 0.9.4
 schema: 1
 scm: github.com/pubnub/kmp-chat
 sdks:
@@ -21,8 +21,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: maven
-              package-name: pubnub-chat-0.9.3
-              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-chat/0.9.3/
+              package-name: pubnub-chat-0.9.4
+              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-chat/0.9.4/
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -77,6 +77,11 @@ sdks:
                   license-url: https://github.com/pubnub/kotlin/blob/master/LICENSE
                   is-required: Required
 changelog:
+  - date: 2024-12-20
+    version: 0.9.4
+    changes:
+      - type: bug
+        text: "Make setRestrictions work with `Enforce referential integrity for memberships` enabled on keyset."
   - date: 2024-12-16
     version: 0.9.3
     changes:

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "PubNubChatRemoteBinaryPackage",
-      url: "https://github.com/pubnub/kmp-chat/releases/download/kotlin-0.9.3/PubNubChat.xcframework.zip",
-      checksum: "dccc53b725a2c5f75936a8b85ae4dab7bd5060ede5b6e19ce80c7ecc35090578"
+      url: "https://github.com/pubnub/kmp-chat/releases/download/kotlin-0.9.4/PubNubChat.xcframework.zip",
+      checksum: "b2971bcc09a9e0107c4bcbf3795fd53ab80608f4dc3dbb7c67ee668009e4b1fe"
     )
   ]
 )

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
       <dependency>
          <groupId>com.pubnub</groupId>
          <artifactId>pubnub-chat</artifactId>
-         <version>0.9.3</version>
+         <version>0.9.4</version>
       </dependency>
       ```
 

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChatTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/kmp/ChatTest.kt
@@ -1346,6 +1346,12 @@ class ChatTest : BaseTest() {
             mute = mute,
             reason = "paid"
         )
+        every { getChannelMetadataEndpoint.async(any()) } calls { (callback1: Consumer<Result<PNChannelMetadataResult>>) ->
+            callback1.accept(Result.success(getPNChannelMetadataResult("PUBNUB_INTERNAL_MODERATION_myChannelId")))
+        }
+        every {
+            pubnub.getChannelMetadata(channel = "PUBNUB_INTERNAL_MODERATION_myChannelId", includeCustom = true)
+        } returns getChannelMetadataEndpoint
         every {
             pubnub.removeChannelMembers(
                 capture(channelIdSlot),
@@ -1405,6 +1411,12 @@ class ChatTest : BaseTest() {
             mute = mute,
             reason = reason
         )
+        every { getChannelMetadataEndpoint.async(any()) } calls { (callback1: Consumer<Result<PNChannelMetadataResult>>) ->
+            callback1.accept(Result.success(getPNChannelMetadataResult("PUBNUB_INTERNAL_MODERATION_myChannelId")))
+        }
+        every {
+            pubnub.getChannelMetadata(channel = "PUBNUB_INTERNAL_MODERATION_myChannelId", includeCustom = true)
+        } returns getChannelMetadataEndpoint
         every {
             pubnub.setChannelMembers(
                 channel = capture(channelIdSlot),


### PR DESCRIPTION
fix: Make setRestrictions work with `Enforce referential integrity for memberships` enabled on keyset