### PR TITLE
Fix Channel type being erased and custom message handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 **/*.podspec
 node_modules
 js-chat/dist
+js-chat/dist-test
 test.properties
 
 ### IntelliJ IDEA ###

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=false
 GROUP=com.pubnub
 POM_PACKAGING=jar
-VERSION_NAME=0.9.5
+VERSION_NAME=0.9.6
 
 POM_NAME=PubNub Chat SDK
 POM_DESCRIPTION=This SDK offers a set of handy methods to create your own feature-rich chat or add a chat to your existing application.

--- a/js-chat/.pubnub.yml
+++ b/js-chat/.pubnub.yml
@@ -6,6 +6,13 @@ schema: 1
 files:
   - lib/dist/index.js
 changelog:
+  - date: 2025-01-02
+    version: 0.9.6
+    changes:
+      - type: bug
+        text: "Channel type was erased (set to `null`) on edits to other Channel fields."
+      - type: bug
+        text: "Custom events sending/receiving in JS."
   - date: 2024-12-20
     version: 0.9.5
     changes:

--- a/js-chat/.pubnub.yml
+++ b/js-chat/.pubnub.yml
@@ -6,11 +6,6 @@ schema: 1
 files:
   - lib/dist/index.js
 changelog:
-  - date: 2025-01-02
-    version: 0.9.6
-    changes:
-      - type: bug
-        text: "Channel type was erased (set to `null`) on edits to other Channel fields."
   - date: 2024-12-20
     version: 0.9.5
     changes:

--- a/js-chat/.pubnub.yml
+++ b/js-chat/.pubnub.yml
@@ -1,11 +1,16 @@
 ---
 name: pubnub-js-chat
-version: 0.9.5
+version: 0.9.6
 scm: github.com/pubnub/js-chat
 schema: 1
 files:
   - lib/dist/index.js
 changelog:
+  - date: 2025-01-02
+    version: 0.9.6
+    changes:
+      - type: bug
+        text: "Channel type was erased (set to `null`) on edits to other Channel fields."
   - date: 2024-12-20
     version: 0.9.5
     changes:

--- a/js-chat/jest.config.js
+++ b/js-chat/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   bail: false,
-  reporters: [["jest-silent-reporter", { "useDots": true }], "jest-junit", "summary"],
+  reporters: ["default", "jest-junit", "summary"],
   testTimeout: 10000
 }

--- a/js-chat/package.json
+++ b/js-chat/package.json
@@ -41,7 +41,7 @@
     "module": "dist/index.es.js",
     "types": "dist/index.d.ts",
     "react-native": "dist/index.es.js",
-    "version": "0.9.5",
+    "version": "0.9.6",
     "name": "@pubnub/chat",
     "dependencies": {
         "pubnub": "8.2.8",

--- a/js-chat/package.json
+++ b/js-chat/package.json
@@ -15,7 +15,7 @@
         "NOTICE"
     ],
     "scripts": {
-        "test": "jest --forceExit",
+        "test": "cp -r dist/ dist-test && rollup --config rollup-test.config.mjs && jest --forceExit",
         "build": "rollup -c",
         "dev": "tsc -w"
     },
@@ -44,7 +44,7 @@
     "version": "0.9.6",
     "name": "@pubnub/chat",
     "dependencies": {
-        "pubnub": "8.2.8",
+        "pubnub": "8.3.1",
         "format-util": "^1.0.5"
     }
 }

--- a/js-chat/package_template.json
+++ b/js-chat/package_template.json
@@ -14,7 +14,7 @@
     "dist", "NOTICE"
   ],
   "scripts": {
-    "test": "jest --forceExit",
+    "test": "cp -r dist/ dist-test && rollup --config rollup-test.config.mjs && jest --forceExit",
     "build": "rollup -c",
     "dev": "tsc -w"
   },

--- a/js-chat/rollup-test.config.mjs
+++ b/js-chat/rollup-test.config.mjs
@@ -1,0 +1,20 @@
+import pkg from "./package.json" assert { type: "json" }
+
+export default [
+  {
+    input: "./main.mjs",
+    external: ["pubnub", "format-util"],
+    output: [
+      {
+        file:  "dist-test/index.js",
+        format: "cjs",
+      },
+      {
+        file: "dist-test/index.es.js",
+        format: "esm",
+      },
+    ],
+    plugins: [
+    ],
+  },
+]

--- a/js-chat/tests/channel.test.ts
+++ b/js-chat/tests/channel.test.ts
@@ -350,6 +350,7 @@ describe("Channel test", () => {
 
   test("should stream channel updates and invoke the callback", async () => {
     let updatedChannel
+    channel = await channel.update({ type: "public" })
     const name = "Updated Channel"
     const callback = jest.fn((chanel) => (updatedChannel = chanel))
 
@@ -360,7 +361,9 @@ describe("Channel test", () => {
     expect(callback).toHaveBeenCalled()
     expect(callback).toHaveBeenCalledWith(updatedChannel)
     expect(updatedChannel.name).toEqual(name)
-
+    expect(updatedChannel.type).toEqual(channel.type)
+    console.log(JSON.stringify(updatedChannel))
+    console.log(JSON.stringify(channel))
     stopUpdates()
   })
 

--- a/js-chat/tests/channel.test.ts
+++ b/js-chat/tests/channel.test.ts
@@ -19,7 +19,7 @@ import {
 import { jest } from "@jest/globals"
 
 describe("Channel test", () => {
-//   jest.retryTimes(3)
+  jest.retryTimes(3)
 
   let chat: Chat
   let channel: Channel
@@ -362,8 +362,6 @@ describe("Channel test", () => {
     expect(callback).toHaveBeenCalledWith(updatedChannel)
     expect(updatedChannel.name).toEqual(name)
     expect(updatedChannel.type).toEqual(channel.type)
-    console.log(JSON.stringify(updatedChannel))
-    console.log(JSON.stringify(channel))
     stopUpdates()
   })
 
@@ -793,8 +791,6 @@ describe("Channel test", () => {
     const usersToInvite = await Promise.all([createRandomUser(), createRandomUser()])
 
     const invitedMemberships = await channel.inviteMultiple(usersToInvite)
-    console.log(JSON.stringify(usersToInvite))
-    console.log(JSON.stringify(invitedMemberships))
 
     expect(invitedMemberships).toBeDefined()
 
@@ -1236,7 +1232,7 @@ describe("Channel test", () => {
   })
 
   test("send custom event", async () => {
-      const inviteCallback = jest.fn(ev => console.log(JSON.stringify(ev)))
+      const inviteCallback = jest.fn()
       const unsubscribe = chat.listenForEvents({
             channel: channel.id,
             type: "custom",
@@ -1247,7 +1243,7 @@ describe("Channel test", () => {
       await sleep(1000)
       await chat.emitEvent({
           channel: channel.id,
-          type: 'custom',
+          type: 'customaaa',
           method: 'publish',
           payload: {
             action: "action",

--- a/js-chat/tests/channel.test.ts
+++ b/js-chat/tests/channel.test.ts
@@ -1243,7 +1243,7 @@ describe("Channel test", () => {
       await sleep(1000)
       await chat.emitEvent({
           channel: channel.id,
-          type: 'customaaa',
+          type: 'custom',
           method: 'publish',
           payload: {
             action: "action",

--- a/js-chat/tests/message-draft-v2.test.ts
+++ b/js-chat/tests/message-draft-v2.test.ts
@@ -1,4 +1,4 @@
-import { Channel, Chat, MessageDraftV2, MixedTextTypedElement } from "../dist"
+import { Channel, Chat, MessageDraftV2, MixedTextTypedElement } from "../dist-test"
 import {
   createChatInstance,
   createRandomChannel,

--- a/js-chat/tests/message-draft.test.ts
+++ b/js-chat/tests/message-draft.test.ts
@@ -1,4 +1,4 @@
-import { Channel, Chat } from "../dist"
+import { Channel, Chat } from "../dist-test"
 import {
   createChatInstance,
   createRandomChannel,

--- a/js-chat/tests/message.test.ts
+++ b/js-chat/tests/message.test.ts
@@ -7,7 +7,7 @@ import {
   CryptoUtils,
   CryptoModule,
   MessageDTOParams,
-} from "../dist"
+} from "../dist-test"
 import {
   createChatInstance,
   createRandomChannel,

--- a/js-chat/tests/testUtils.ts
+++ b/js-chat/tests/testUtils.ts
@@ -1,9 +1,9 @@
 // lib/tests/testUtils.ts
-import { Chat } from "../dist"
-import { Channel } from "../dist"
+import { Chat } from "../dist-test"
+import { Channel } from "../dist-test"
 import * as dotenv from "dotenv"
 import { nanoid } from "nanoid"
-import { User } from "../dist"
+import { User } from "../dist-test"
 
 dotenv.config()
 

--- a/js-chat/tests/timetoken.test.ts
+++ b/js-chat/tests/timetoken.test.ts
@@ -1,4 +1,4 @@
-import { TimetokenUtils } from "../dist"
+import { TimetokenUtils } from "../dist-test"
 
 describe("Channel test", () => {
   test("should convert unix timestamp to PubNub timetoken", () => {

--- a/js-chat/tests/typing-indicator.test.ts
+++ b/js-chat/tests/typing-indicator.test.ts
@@ -1,4 +1,4 @@
-import { Channel, Chat } from "../dist"
+import { Channel, Chat } from "../dist-test"
 import { createChatInstance, createRandomChannel, sleep } from "./utils"
 
 describe("Typing indicator test", () => {

--- a/js-chat/tests/user.test.ts
+++ b/js-chat/tests/user.test.ts
@@ -1,6 +1,6 @@
-import { Chat, INTERNAL_MODERATION_PREFIX, User } from "../dist"
+import { Chat, INTERNAL_MODERATION_PREFIX, User } from "../dist-test"
 import { createChatInstance, createRandomUser, sleep } from "./utils"
-import { INTERNAL_ADMIN_CHANNEL } from "../dist"
+import { INTERNAL_ADMIN_CHANNEL } from "../dist-test"
 
 describe("User test", () => {
   let chat: Chat

--- a/js-chat/tests/utils.ts
+++ b/js-chat/tests/utils.ts
@@ -1,8 +1,8 @@
 // lib/tests/testUtils.ts
-import { Chat, MessageDraft, Channel, Message, ChatConfig } from "../dist"
+import { Chat, MessageDraft, Channel, Message, ChatConfig } from "../dist-test"
 import * as dotenv from "dotenv"
-import { User } from "../dist"
-import { MixedTextTypedElement } from "../dist"
+import { User } from "../dist-test"
+import { MixedTextTypedElement } from "../dist-test"
 import PubNub from "pubnub"
 
 dotenv.config()

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/utils/json.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/utils/json.kt
@@ -1,3 +1,5 @@
+import com.pubnub.chat.internal.TYPE_OF_MESSAGE
+import com.pubnub.chat.internal.TYPE_OF_MESSAGE_IS_CUSTOM
 import com.pubnub.chat.internal.defaultGetMessagePublishBody
 import com.pubnub.chat.internal.serialization.PNDataEncoder
 import com.pubnub.chat.types.EventContent
@@ -53,7 +55,7 @@ internal fun EventContent.encodeForSending(
     var finalMessage = if (this is EventContent.Custom) {
         buildMap<String, Any?> {
             putAll(data)
-            put("type", "custom")
+            put(TYPE_OF_MESSAGE, TYPE_OF_MESSAGE_IS_CUSTOM)
         }
     } else {
         PNDataEncoder.encode(this) as Map<String, Any?>

--- a/pubnub-chat-impl/src/jsMain/kotlin/ChannelJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/ChannelJs.kt
@@ -31,10 +31,10 @@ open class ChannelJs internal constructor(internal val channel: Channel, interna
     fun update(data: ChannelFields): Promise<ChannelJs> {
         return channel.update(
             data.name,
-            convertToCustomObject(data.custom),
+            data.custom?.let { convertToCustomObject(it) },
             data.description,
             data.status,
-            ChannelType.from(data.type)
+            data.type?.let { ChannelType.from(it) }
         ).then {
             it.asJs(chatJs)
         }.asPromise()

--- a/pubnub-chat-impl/src/jsMain/kotlin/ChatJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/ChatJs.kt
@@ -89,7 +89,7 @@ class ChatJs internal constructor(val chat: ChatInternal, val config: ChatConfig
             data.externalId,
             data.profileUrl,
             data.email,
-            convertToCustomObject(data.custom),
+            data.custom?.let { convertToCustomObject(data.custom) },
             data.status,
             data.type
         ).then { it.asJs(this@ChatJs) }.asPromise()
@@ -102,7 +102,7 @@ class ChatJs internal constructor(val chat: ChatInternal, val config: ChatConfig
             data.externalId,
             data.profileUrl,
             data.email,
-            convertToCustomObject(data.custom),
+            data.custom?.let { convertToCustomObject(data.custom) },
             data.status,
             data.type
         ).then { it.asJs(this@ChatJs) }.asPromise()
@@ -142,10 +142,10 @@ class ChatJs internal constructor(val chat: ChatInternal, val config: ChatConfig
         return chat.updateChannel(
             id,
             data.name,
-            convertToCustomObject(data.custom),
+            data.custom?.let { convertToCustomObject(it) },
             data.description,
             data.status,
-            ChannelType.from(data.type)
+            data.type?.let { ChannelType.from(data.type) }
         ).then { it.asJs(this@ChatJs) }.asPromise()
     }
 

--- a/pubnub-chat-impl/src/jsMain/kotlin/MembershipJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/MembershipJs.kt
@@ -19,8 +19,8 @@ class MembershipJs internal constructor(internal val membership: Membership, int
 
     val lastReadMessageTimetoken: String? get() = membership.lastReadMessageTimetoken?.toString()
 
-    fun update(custom: dynamic): Promise<MembershipJs> {
-        return membership.update(convertToCustomObject(custom?.custom))
+    fun update(custom: UpdateMembershipParams?): Promise<MembershipJs> {
+        return membership.update(custom?.custom?.let { convertToCustomObject(it) })
             .then { it.asJs(chatJs) }
             .asPromise()
     }

--- a/pubnub-chat-impl/src/jsMain/kotlin/ThreadChannelJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/ThreadChannelJs.kt
@@ -2,6 +2,8 @@
 
 import com.pubnub.chat.Event
 import com.pubnub.chat.ThreadChannel
+import com.pubnub.chat.internal.TYPE_OF_MESSAGE
+import com.pubnub.chat.internal.TYPE_OF_MESSAGE_IS_CUSTOM
 import com.pubnub.chat.types.EventContent
 import com.pubnub.kmp.createJsObject
 import com.pubnub.kmp.then
@@ -54,7 +56,7 @@ internal fun Event<*>.toJs(chatJs: ChatJs): EventJs {
         EventJs(
             chatJs,
             timetoken.toString(),
-            "custom",
+            TYPE_OF_MESSAGE_IS_CUSTOM,
             customPayload.data.toJsObject(),
             channelId,
             userId
@@ -65,7 +67,7 @@ internal fun Event<*>.toJs(chatJs: ChatJs): EventJs {
             timetoken.toString(),
             payload::class.serializer().descriptor.serialName,
             payload.toJsObject().apply {
-                delete(this.asDynamic()["type"])
+                delete(this.asDynamic()[TYPE_OF_MESSAGE])
             },
             channelId,
             userId

--- a/pubnub-chat-impl/src/jsMain/kotlin/ThreadChannelJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/ThreadChannelJs.kt
@@ -2,6 +2,7 @@
 
 import com.pubnub.chat.Event
 import com.pubnub.chat.ThreadChannel
+import com.pubnub.chat.types.EventContent
 import com.pubnub.kmp.createJsObject
 import com.pubnub.kmp.then
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -48,16 +49,28 @@ external fun delete(p: dynamic): Boolean
 
 @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
 internal fun Event<*>.toJs(chatJs: ChatJs): EventJs {
-    return EventJs(
-        chatJs,
-        timetoken.toString(),
-        payload::class.serializer().descriptor.serialName,
-        payload.toJsObject().apply {
-            delete(this.asDynamic()["type"])
-        },
-        channelId,
-        userId
-    )
+    val customPayload = payload as? EventContent.Custom
+    return if (customPayload != null) {
+        EventJs(
+            chatJs,
+            timetoken.toString(),
+            "custom",
+            customPayload.data.toJsObject(),
+            channelId,
+            userId
+        )
+    } else {
+        EventJs(
+            chatJs,
+            timetoken.toString(),
+            payload::class.serializer().descriptor.serialName,
+            payload.toJsObject().apply {
+                delete(this.asDynamic()["type"])
+            },
+            channelId,
+            userId
+        )
+    }
 }
 
 internal fun ThreadChannel.asJs(chat: ChatJs) = ThreadChannelJs(this, chat)

--- a/pubnub-chat-impl/src/jsMain/kotlin/UserJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/UserJs.kt
@@ -30,7 +30,7 @@ class UserJs internal constructor(internal val user: User, internal val chatJs: 
             data.externalId,
             data.profileUrl,
             data.email,
-            convertToCustomObject(data.custom),
+            data.custom?.let { convertToCustomObject(it) },
             data.status,
             data.type
         ).then {

--- a/pubnub-chat-impl/src/jsMain/kotlin/types.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/types.kt
@@ -310,3 +310,7 @@ external interface Reaction {
     var uuid: String
     var actionTimetoken: String
 }
+
+external interface UpdateMembershipParams {
+    val custom: PubNub.CustomObject?
+}


### PR DESCRIPTION
fix: Channel type was erased (set to `null`) on edits to other Channel fields
fix: custom events sending/receiving in JS