### PR TITLE
Change TS types to use type declarations from PN JS SDK

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=false
 GROUP=com.pubnub
 POM_PACKAGING=jar
-VERSION_NAME=0.10.1
+VERSION_NAME=0.11.0
 
 POM_NAME=PubNub Chat SDK
 POM_DESCRIPTION=This SDK offers a set of handy methods to create your own feature-rich chat or add a chat to your existing application.

--- a/js-chat/.pubnub.yml
+++ b/js-chat/.pubnub.yml
@@ -1,10 +1,15 @@
 name: pubnub-js-chat
-version: 0.10.0
+version: 0.11.0
 scm: github.com/pubnub/js-chat
 schema: 1
 files:
   - lib/dist/index.js
 changelog:
+  - date: 2025-01-16
+    version: 0.11.0
+    changes:
+      - type: improvement
+        text: "The JS Chat SDK now uses TS types from recent versions of PubNub JS SDK instead of the ones in the `@types/pubnub` community resource. Changes to customer code might be required to accommodate this change."
   - date: 2025-01-08
     version: 0.10.0
     changes:

--- a/js-chat/package.json
+++ b/js-chat/package.json
@@ -40,7 +40,7 @@
     "module": "dist/index.es.js",
     "types": "dist/index.d.ts",
     "react-native": "dist/index.es.js",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "name": "@pubnub/chat",
     "dependencies": {
         "pubnub": "8.4.1",

--- a/js-chat/package.json
+++ b/js-chat/package.json
@@ -27,7 +27,6 @@
         "@rollup/plugin-terser": "^0.4.3",
         "@rollup/plugin-commonjs": "28.0.1",
         "@types/jest": "29.5.0",
-        "@types/pubnub": "7.4.2",
         "babel-jest": "29.5.0",
         "dotenv": "16.0.3",
         "jest": "29.5.0",

--- a/js-chat/package_template.json
+++ b/js-chat/package_template.json
@@ -26,7 +26,6 @@
     "@rollup/plugin-terser": "^0.4.3",
     "@rollup/plugin-commonjs": "28.0.1",
     "@types/jest": "29.5.0",
-    "@types/pubnub": "7.4.2",
     "babel-jest": "29.5.0",
     "dotenv": "16.0.3",
     "jest": "29.5.0",

--- a/js-chat/tests/channel.test.ts
+++ b/js-chat/tests/channel.test.ts
@@ -1261,4 +1261,12 @@ describe("Channel test", () => {
         })
       )
     })
+
+  test.only("use PubNub SDK types from Chat SDK", async () => {
+    let channelMetadata = await chat.sdk.objects.getChannelMetadata({
+      channel: channel.id,
+      include: { customFields: true }
+    })
+    expect(channelMetadata).toBeDefined()
+  })
 })

--- a/js-chat/tests/channel.test.ts
+++ b/js-chat/tests/channel.test.ts
@@ -1156,7 +1156,11 @@ describe("Channel test", () => {
         channelTypeField: true,
         statusField: true,
         channelStatusField: true,
+        typeField: true,
       },
+      limit: null,
+      page: null,
+      sort: {},
       uuid: chat.currentUser.id,
     }
 
@@ -1262,7 +1266,7 @@ describe("Channel test", () => {
       )
     })
 
-  test.only("use PubNub SDK types from Chat SDK", async () => {
+  test("use PubNub SDK types from Chat SDK", async () => {
     let channelMetadata = await chat.sdk.objects.getChannelMetadata({
       channel: channel.id,
       include: { customFields: true }

--- a/js-chat/tests/user.test.ts
+++ b/js-chat/tests/user.test.ts
@@ -190,7 +190,11 @@ describe("User test", () => {
         channelTypeField: true,
         statusField: true,
         channelStatusField: true,
+        typeField: true,
       },
+      limit: null,
+      page: null,
+      sort: {},
       uuid: chat.currentUser.id,
     }
 


### PR DESCRIPTION
refactor: The JS Chat SDK now uses TS types from recent versions of PubNub JS SDK instead of the ones in the `@types/pubnub` community resource. Changes to customer code might be required to accommodate this change.