### PR TITLE
[JS] Preserve custom message payload

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=false
 GROUP=com.pubnub
 POM_PACKAGING=jar
-VERSION_NAME=0.11.2
+VERSION_NAME=0.11.3
 
 POM_NAME=PubNub Chat SDK
 POM_DESCRIPTION=This SDK offers a set of handy methods to create your own feature-rich chat or add a chat to your existing application.

--- a/js-chat/.pubnub.yml
+++ b/js-chat/.pubnub.yml
@@ -1,10 +1,15 @@
 name: pubnub-js-chat
-version: 0.11.2
+version: 0.11.3
 scm: github.com/pubnub/js-chat
 schema: 1
 files:
   - lib/dist/index.js
 changelog:
+  - date: 2025-01-30
+    version: 0.11.3
+    changes:
+      - type: bug
+        text: "When using the CustomPayloads configuration option in JS, allow the user to specify custom keys and preserve them when receiving messages."
   - date: 2025-01-30
     version: 0.11.2
     changes:

--- a/js-chat/package.json
+++ b/js-chat/package.json
@@ -40,7 +40,7 @@
     "module": "dist/index.es.js",
     "types": "dist/index.d.ts",
     "react-native": "dist/index.es.js",
-    "version": "0.11.2",
+    "version": "0.11.3",
     "name": "@pubnub/chat",
     "dependencies": {
         "pubnub": "8.6.0",

--- a/js-chat/tests/message.test.ts
+++ b/js-chat/tests/message.test.ts
@@ -1377,6 +1377,7 @@ describe("Send message test", () => {
               text: messageParams.message.body.message.content.text,
               type: messageParams.message.messageType,
               files: messageParams.message.body.files,
+              customKey: "customValue"
             }
           },
         },
@@ -1392,6 +1393,7 @@ describe("Send message test", () => {
 
     const historyObject = await someChannel.getHistory({ count: 1 })
     expect(historyObject.messages[0].text).toBe("Hello world!")
+    expect(historyObject.messages[0].content.customKey).toBe("customValue")
   })
 
   test("should send a message with custom body and crash if getMessageResponseBody is incorrect", async () => {

--- a/pubnub-chat-api/api/pubnub-chat-api.api
+++ b/pubnub-chat-api/api/pubnub-chat-api.api
@@ -551,9 +551,10 @@ public final class com/pubnub/chat/types/EmitEventMethod : java/lang/Enum {
 
 public abstract class com/pubnub/chat/types/EventContent {
 	public static final field Companion Lcom/pubnub/chat/types/EventContent$Companion;
+	public fun <init> ()V
 	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCustomMessageType ()Ljava/lang/String;
 	public static final synthetic fun write$Self (Lcom/pubnub/chat/types/EventContent;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/types/Types.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/types/Types.kt
@@ -35,7 +35,7 @@ class File(
  * [com.pubnub.api.PubNub.publish] or [com.pubnub.api.PubNub.signal] when sending this event.
  */
 @Serializable
-sealed class EventContent(
+abstract class EventContent(
     @Transient val customMessageType: String? = null
 ) {
     /**

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/types/Types.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/types/Types.kt
@@ -29,7 +29,7 @@ class File(
 
 /**
  * Represents the content of various types of events emitted during chat operations.
- * This is a sealed class with different subclasses representing specific types of events.
+ * This is an abstract class with different subclasses representing specific types of events.
  *
  * @property customMessageType the `customMessageType` that will be passed as a parameter into
  * [com.pubnub.api.PubNub.publish] or [com.pubnub.api.PubNub.signal] when sending this event.

--- a/pubnub-chat-impl/config/ktlint/baseline.xml
+++ b/pubnub-chat-impl/config/ktlint/baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
     <file name="src/jsMain/kotlin/converters.kt">
-        <error line="156" column="14" source="standard:function-naming" />
+        <error line="160" column="14" source="standard:function-naming" />
     </file>
 </baseline>

--- a/pubnub-chat-impl/config/ktlint/baseline.xml
+++ b/pubnub-chat-impl/config/ktlint/baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
     <file name="src/jsMain/kotlin/converters.kt">
-        <error line="146" column="14" source="standard:function-naming" />
+        <error line="156" column="14" source="standard:function-naming" />
     </file>
 </baseline>

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/serialization/JsonElementDecoder.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/serialization/JsonElementDecoder.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 
 class JsonElementDecoder(
@@ -30,7 +29,7 @@ class JsonElementDecoder(
 //    }
     private var counter = 0
 
-    override val serializersModule: SerializersModule = EmptySerializersModule()
+    override val serializersModule: SerializersModule = module
 
     override fun decodeBooleanElement(descriptor: SerialDescriptor, index: Int): Boolean {
         return (

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/serialization/encoders.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/serialization/encoders.kt
@@ -3,6 +3,7 @@
 package com.pubnub.chat.internal.serialization
 
 import com.pubnub.api.JsonElement
+import com.pubnub.chat.types.EventContent
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
@@ -11,14 +12,27 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
 import kotlinx.serialization.serializer
+
+val module = SerializersModule {
+    polymorphic(EventContent::class) {
+        subclass(EventContent.Typing::class)
+        subclass(EventContent.Report::class)
+        subclass(EventContent.Receipt::class)
+        subclass(EventContent.Mention::class)
+        subclass(EventContent.Moderation::class)
+        subclass(EventContent.TextMessageContent::class)
+        subclass(EventContent.Invite::class)
+    }
+}
 
 class AnyEncoder : Encoder, CompositeEncoder {
     var returnValue: Any? = null
     private var nextSerialNameValue: Pair<String, String>? = null
-    override val serializersModule: SerializersModule = EmptySerializersModule()
+    override val serializersModule: SerializersModule = module
 
     override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) {
         returnValue = value
@@ -186,7 +200,7 @@ class MapEncoder(polymorphicType: Pair<String, String>? = null) : CompositeEncod
             put(polymorphicType.first, polymorphicType.second)
         }
     }
-    override val serializersModule: SerializersModule = EmptySerializersModule()
+    override val serializersModule: SerializersModule = module
 
     override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) {
         encodeValue(descriptor, index, value)
@@ -272,7 +286,7 @@ class MapEncoder(polymorphicType: Pair<String, String>? = null) : CompositeEncod
 
 class ListEncoder : CompositeEncoder {
     val list: MutableList<Any?> = mutableListOf()
-    override val serializersModule: SerializersModule = EmptySerializersModule()
+    override val serializersModule: SerializersModule = module
 
     override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) {
         list.add(value)

--- a/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/internal/AnyEncoderTest.kt
+++ b/pubnub-chat-impl/src/commonTest/kotlin/com/pubnub/internal/AnyEncoderTest.kt
@@ -1,6 +1,7 @@
 package com.pubnub.internal
 
 import com.pubnub.chat.internal.serialization.PNDataEncoder
+import com.pubnub.chat.types.EventContent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
@@ -166,5 +167,11 @@ class AnyEncoderTest {
             ),
             encodedMap
         )
+    }
+
+    @Test
+    fun testEncodeTextMessageContent() {
+        val map = PNDataEncoder.encode(EventContent.TextMessageContent("abc", null) as EventContent) as Map<String, Any?>
+        assertEquals("abc", map["text"])
     }
 }

--- a/pubnub-chat-impl/src/jsMain/kotlin/MessageJs.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/MessageJs.kt
@@ -5,7 +5,6 @@ import com.pubnub.api.adjustCollectionTypes
 import com.pubnub.chat.Message
 import com.pubnub.chat.internal.MessageDraftImpl
 import com.pubnub.chat.internal.message.BaseMessage
-import com.pubnub.chat.types.EventContent
 import com.pubnub.chat.types.MessageMentionedUser
 import com.pubnub.chat.types.MessageReferencedChannel
 import com.pubnub.kmp.JsMap
@@ -22,7 +21,10 @@ import kotlin.js.json
 open class MessageJs internal constructor(internal val message: Message, internal val chatJs: ChatJs) {
     val hasThread by message::hasThread
     val timetoken: String get() = message.timetoken.toString()
-    val content get() = (message.content as EventContent).toJsObject()
+    val content: JsMap<Any?>
+        get() {
+            return message.content.toJsTextMessage()
+        }
     val channelId by message::channelId
     val userId by message::userId
     val actions get() = message.actions?.mapValues {

--- a/pubnub-chat-impl/src/jsMain/kotlin/converters.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/converters.kt
@@ -82,12 +82,16 @@ internal inline fun Map<String, Any?>.toJsObject(): JsMap<Any?> {
     return createJsonElement(this).value.unsafeCast<JsMap<Any?>>()
 }
 
-internal class TextMessageContentWithCustom(text: String, files: List<File>?, internal val customData: Any) : EventContent.TextMessageContent(
+internal class TextMessageContentWithCustom(text: String, files: List<File>?, internal val customJsObject: Any) : EventContent.TextMessageContent(
     text,
     files
 )
 
-internal fun EventContent.TextMessageContent.withJsObject(customData: Any) = TextMessageContentWithCustom(text, files, customData)
+internal fun EventContent.TextMessageContent.withCustomJsObject(customJsObject: Any) = TextMessageContentWithCustom(
+    text,
+    files,
+    customJsObject
+)
 
 internal fun CustomPayloadsJs?.toKmp(): CustomPayloads {
     if (this == null) {
@@ -117,7 +121,7 @@ internal fun CustomPayloadsJs?.toKmp(): CustomPayloads {
                 messageDTOparams.message = jsMap
                 val resultingMessage = mrb(messageDTOparams)
                 val textMessageContent = PNDataEncoder.decode<EventContent.TextMessageContent?>(createJsonElement(resultingMessage))
-                return textMessageContent?.withJsObject(resultingMessage)
+                return textMessageContent?.withCustomJsObject(resultingMessage)
             }
         },
         editMessageActionName = editMessageActionName,
@@ -196,6 +200,6 @@ private fun RateLimitPerChannelJs?.toKmp(): Map<ChannelType, Duration> {
 
 internal fun EventContent.TextMessageContent.toJsTextMessage(): JsMap<Any?> =
     (
-        (this as? TextMessageContentWithCustom)?.customData?.unsafeCast<JsMap<Any?>>()
+        (this as? TextMessageContentWithCustom)?.customJsObject?.unsafeCast<JsMap<Any?>>()
             ?: (this as EventContent).toJsObject()
     )

--- a/pubnub-chat-impl/src/jsMain/kotlin/converters.kt
+++ b/pubnub-chat-impl/src/jsMain/kotlin/converters.kt
@@ -17,6 +17,7 @@ import com.pubnub.chat.restrictions.GetRestrictionsResponse
 import com.pubnub.chat.restrictions.Restriction
 import com.pubnub.chat.types.ChannelType
 import com.pubnub.chat.types.EventContent
+import com.pubnub.chat.types.File
 import com.pubnub.chat.types.QuotedMessage
 import com.pubnub.kmp.JsMap
 import com.pubnub.kmp.PNFuture
@@ -81,6 +82,13 @@ internal inline fun Map<String, Any?>.toJsObject(): JsMap<Any?> {
     return createJsonElement(this).value.unsafeCast<JsMap<Any?>>()
 }
 
+internal class TextMessageContentWithCustom(text: String, files: List<File>?, internal val customData: Any) : EventContent.TextMessageContent(
+    text,
+    files
+)
+
+internal fun EventContent.TextMessageContent.withJsObject(customData: Any) = TextMessageContentWithCustom(text, files, customData)
+
 internal fun CustomPayloadsJs?.toKmp(): CustomPayloads {
     if (this == null) {
         return CustomPayloads()
@@ -92,7 +100,7 @@ internal fun CustomPayloadsJs?.toKmp(): CustomPayloads {
                     channelId: String,
                     defaultMessagePublishBody: (m: EventContent.TextMessageContent) -> Map<String, Any?> ->
                 mpb(
-                    (m as EventContent).toJsObject(),
+                    m.toJsTextMessage(),
                     channelId
                 ).unsafeCast<JsMap<Any>>().toMap()
             }
@@ -103,11 +111,13 @@ internal fun CustomPayloadsJs?.toKmp(): CustomPayloads {
                 channelId: String,
                 defaultMessageResponseBody: (JsonElement) -> EventContent.TextMessageContent?
             ): EventContent.TextMessageContent? {
-                val jsM = m.value.unsafeCast<JsMap<Any?>>()
+                val jsMap = m.value.unsafeCast<JsMap<Any?>>()
                 val messageDTOparams = Any().asDynamic()
                 messageDTOparams.channel = channelId
-                messageDTOparams.message = jsM
-                return PNDataEncoder.decode(createJsonElement(mrb(messageDTOparams)))
+                messageDTOparams.message = jsMap
+                val resultingMessage = mrb(messageDTOparams)
+                val textMessageContent = PNDataEncoder.decode<EventContent.TextMessageContent?>(createJsonElement(resultingMessage))
+                return textMessageContent?.withJsObject(resultingMessage)
             }
         },
         editMessageActionName = editMessageActionName,
@@ -183,3 +193,9 @@ private fun RateLimitPerChannelJs?.toKmp(): Map<ChannelType, Duration> {
     }
     return resultingMap
 }
+
+internal fun EventContent.TextMessageContent.toJsTextMessage(): JsMap<Any?> =
+    (
+        (this as? TextMessageContentWithCustom)?.customData?.unsafeCast<JsMap<Any?>>()
+            ?: (this as EventContent).toJsObject()
+    )


### PR DESCRIPTION
fix: When using the CustomPayloads configuration option in JS, allow the user to specify custom keys and preserve them when receiving messages.