### PR TITLE
Add ability to specify custom data in Push payloads

### DIFF
--- a/pubnub-chat-api/api/pubnub-chat-api.api
+++ b/pubnub-chat-api/api/pubnub-chat-api.api
@@ -38,9 +38,9 @@ public abstract interface class com/pubnub/chat/Channel {
 	public abstract fun pinMessage (Lcom/pubnub/chat/Message;)Lcom/pubnub/kmp/PNFuture;
 	public abstract fun plus (Lcom/pubnub/api/models/consumer/objects/channel/PNChannelMetadata;)Lcom/pubnub/chat/Channel;
 	public abstract fun registerForPush ()Lcom/pubnub/kmp/PNFuture;
-	public abstract fun sendText (Ljava/lang/String;Ljava/util/Map;ZZLjava/lang/Integer;Lcom/pubnub/chat/Message;Ljava/util/List;Ljava/util/Collection;)Lcom/pubnub/kmp/PNFuture;
+	public abstract fun sendText (Ljava/lang/String;Ljava/util/Map;ZZLjava/lang/Integer;Lcom/pubnub/chat/Message;Ljava/util/List;Ljava/util/Collection;Ljava/util/Map;)Lcom/pubnub/kmp/PNFuture;
 	public abstract fun sendText (Ljava/lang/String;Ljava/util/Map;ZZLjava/lang/Integer;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Lcom/pubnub/chat/Message;Ljava/util/List;)Lcom/pubnub/kmp/PNFuture;
-	public static synthetic fun sendText$default (Lcom/pubnub/chat/Channel;Ljava/lang/String;Ljava/util/Map;ZZLjava/lang/Integer;Lcom/pubnub/chat/Message;Ljava/util/List;Ljava/util/Collection;ILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;
+	public static synthetic fun sendText$default (Lcom/pubnub/chat/Channel;Ljava/lang/String;Ljava/util/Map;ZZLjava/lang/Integer;Lcom/pubnub/chat/Message;Ljava/util/List;Ljava/util/Collection;Ljava/util/Map;ILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;
 	public static synthetic fun sendText$default (Lcom/pubnub/chat/Channel;Ljava/lang/String;Ljava/util/Map;ZZLjava/lang/Integer;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Lcom/pubnub/chat/Message;Ljava/util/List;ILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;
 	public abstract fun setRestrictions (Lcom/pubnub/chat/User;ZZLjava/lang/String;)Lcom/pubnub/kmp/PNFuture;
 	public static synthetic fun setRestrictions$default (Lcom/pubnub/chat/Channel;Lcom/pubnub/chat/User;ZZLjava/lang/String;ILjava/lang/Object;)Lcom/pubnub/kmp/PNFuture;

--- a/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Channel.kt
+++ b/pubnub-chat-api/src/commonMain/kotlin/com/pubnub/chat/Channel.kt
@@ -224,6 +224,8 @@ interface Channel {
      * original message content, and userId as the identifier of the user who published the quoted message.
      * @param files One or multiple files attached to the text message.
      * @param usersToMention A collection of user ids to automatically notify with a mention after this message is sent.
+     * @param customPushData Additional key-value pairs that will be added to the FCM and/or APNS push messages for the
+     * message itself and any user mentions.
      *
      * @return [PNFuture] containing [PNPublishResult] that holds the timetoken of the sent message.
      */
@@ -236,6 +238,7 @@ interface Channel {
         quotedMessage: Message? = null,
         files: List<InputFile>? = null,
         usersToMention: Collection<String>? = null,
+        customPushData: Map<String, String>? = null
     ): PNFuture<PNPublishResult>
 
     /**

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/BaseChannel.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/BaseChannel.kt
@@ -280,6 +280,7 @@ abstract class BaseChannel<C : Channel, M : Message>(
         quotedMessage: Message?,
         files: List<InputFile>?,
         usersToMention: Collection<String>?,
+        customPushData: Map<String, String>?,
     ): PNFuture<PNPublishResult> {
         return sendTextInternal(
             text = text,
@@ -289,7 +290,8 @@ abstract class BaseChannel<C : Channel, M : Message>(
             ttl = ttl,
             quotedMessage = quotedMessage,
             files = files,
-            usersToMention = usersToMention
+            usersToMention = usersToMention,
+            customPushData = customPushData,
         )
     }
 
@@ -301,7 +303,8 @@ abstract class BaseChannel<C : Channel, M : Message>(
         ttl: Int?,
         quotedMessage: Message?,
         files: List<InputFile>?,
-        usersToMention: Collection<String>? = null
+        usersToMention: Collection<String>? = null,
+        customPushData: Map<String, String>? = null,
     ): PNFuture<PNPublishResult> {
         if (quotedMessage != null && quotedMessage.channelId != id) {
             return log.logErrorAndReturnException(CANNOT_QUOTE_MESSAGE_FROM_OTHER_CHANNELS).asFuture()
@@ -313,7 +316,7 @@ abstract class BaseChannel<C : Channel, M : Message>(
                     message = EventContent.TextMessageContent(text, filesData).encodeForSending(
                         id,
                         chat.config.customPayloads?.getMessagePublishBody,
-                        getPushPayload(this, text, chat.config.pushNotifications)
+                        getPushPayload(this, text, chat.config.pushNotifications, customPushData)
                     ),
                     meta = meta,
                     shouldStore = shouldStore,
@@ -322,7 +325,7 @@ abstract class BaseChannel<C : Channel, M : Message>(
                 )
             }.then { publishResult: PNPublishResult ->
                 usersToMention?.forEach { mentionedUser ->
-                    emitUserMention(mentionedUser, publishResult.timetoken, text).async {
+                    emitUserMention(mentionedUser, publishResult.timetoken, text, customPushData).async {
                         it.onFailure { ex ->
                             log.w(throwable = ex) { ex.message.orEmpty() }
                         }
@@ -765,11 +768,12 @@ abstract class BaseChannel<C : Channel, M : Message>(
         userId: String,
         timetoken: Long,
         text: String,
+        customPushData: Map<String, String>? = null,
     ): PNFuture<PNPublishResult> {
         return chat.emitEvent(
             userId,
             EventContent.Mention(timetoken, id),
-            getPushPayload(this, text, chat.config.pushNotifications)
+            getPushPayload(this, text, chat.config.pushNotifications, customPushData)
         )
     }
 
@@ -888,7 +892,8 @@ abstract class BaseChannel<C : Channel, M : Message>(
         internal fun getPushPayload(
             baseChannel: BaseChannel<*, *>,
             text: String,
-            pushConfig: PushNotificationsConfig
+            pushConfig: PushNotificationsConfig,
+            customPushData: Map<String, String>? = null
         ): Map<String, Any> {
             val apnsTopic = pushConfig.apnsTopic
             val apnsEnv = pushConfig.apnsEnvironment
@@ -904,6 +909,7 @@ abstract class BaseChannel<C : Channel, M : Message>(
                 }
                 data = buildMap {
                     baseChannel.name?.let { put("subtitle", it) }
+                    customPushData?.let { putAll(it) }
                 }
                 this.android = PushPayloadHelper.FCMPayloadV2.AndroidConfig().apply {
                     this.notification = PushPayloadHelper.FCMPayloadV2.AndroidConfig.AndroidNotification().apply {
@@ -932,7 +938,10 @@ abstract class BaseChannel<C : Channel, M : Message>(
                             )
                         }
                     )
-                    baseChannel.name?.let { custom = mapOf("subtitle" to it) }
+                    custom = buildMap {
+                        baseChannel.name?.let { put("subtitle", it) }
+                        customPushData?.let { putAll(it) }
+                    }
                 }
             }
 

--- a/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ThreadChannelImpl.kt
+++ b/pubnub-chat-impl/src/commonMain/kotlin/com/pubnub/chat/internal/channel/ThreadChannelImpl.kt
@@ -140,6 +140,7 @@ data class ThreadChannelImpl(
         quotedMessage: Message?,
         files: List<InputFile>?,
         usersToMention: Collection<String>?,
+        customPushData: Map<String, String>?,
     ): PNFuture<PNPublishResult> {
         return createThreadAndSend {
             super.sendText(
@@ -150,18 +151,24 @@ data class ThreadChannelImpl(
                 ttl = ttl,
                 quotedMessage = quotedMessage,
                 files = files,
-                usersToMention = usersToMention
+                usersToMention = usersToMention,
+                customPushData = customPushData,
             )
         }
     }
 
     override fun copyWithStatusDeleted(): ThreadChannel = copy(status = DELETED)
 
-    override fun emitUserMention(userId: String, timetoken: Long, text: String): PNFuture<PNPublishResult> {
+    override fun emitUserMention(
+        userId: String,
+        timetoken: Long,
+        text: String,
+        customPushData: Map<String, String>?,
+    ): PNFuture<PNPublishResult> {
         return chat.emitEvent(
             userId,
             EventContent.Mention(timetoken, id, parentChannelId),
-            getPushPayload(this, text, chat.config.pushNotifications)
+            getPushPayload(this, text, chat.config.pushNotifications, customPushData)
         )
     }
 


### PR DESCRIPTION
A new optional parameter for `Channel.sendText` - `customPushData: Map<String,String>` that lets users specify custom key values that will be put into the FCM message (in `data`) and/or APNS (in root object) that is sent with the message and also with every user mention.